### PR TITLE
Travis CI: Add PHP 5.5 and use more build defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+
+install: composer install
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php --
-  - php composer.phar install
   - git config --global user.email "test@test.com"
   - git config --global user.name "John Doe"
-
-script: phpunit
 
 notifications:
   email:


### PR DESCRIPTION
**About Travis wrong build errors:**

**Attention:** At the moment, there is an issue on travis-ci.org side, that make RMT builds to fail (see travis-ci/travis-ci#1188 for bug-tracking records and #34 for the final fix).

**About these insignificant proposed changes:**

Beside adding `5.5` to the build matrix, other changes are just cosmetics (aiming to simplify `.travis.yml`). Let me know if you:
- prefer to still use `composer` from http://getcomposer.org/installer instead of preinstalled version.
- still want to explicitly declare `script: phpunit` 

Note: `install: composer install ...` as default [was originally planned](https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/php.rb#L26). I would like to know if such feature would be appreciated on your side...
