### PR TITLE
Handle output of `git branch` with git v1.8+

### DIFF
--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -77,7 +77,7 @@ class Git extends BaseVCS
     {
         $branches = $this->executeGitCommand('branch');
         foreach ($branches as $branch){
-            if (strpos($branch, '* ') === 0 && $branch !== '* (no branch)'){
+            if (strpos($branch, '* ') === 0 && $branch !== '* (no branch)' && strpos($branch, '* (detached from ') !== 0) {
                 return substr($branch,2);
             }
         }


### PR DESCRIPTION
In a detached state, `git branch` output has changed:

With git 1.8.3.1 

```
* (detached from 9aca70b)
  master
```

With git 1.7.9.5:

```
* (no branch)
  master
```

travis-ci.org build environments are installed with git packages from https://launchpad.net/~pdoes/+archive/ppa. [New travis VMs](http://about.travis-ci.org/blog/2013-06-17-time-for-a-vm-update) recently upgraded git version, hence these recent build errors.
