### PR TITLE
improve exception message when git command fails

### DIFF
--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -101,9 +101,8 @@ class Git extends BaseVCS
         $cmd = 'git '.$cmd;
         exec($cmd, $result, $exitCode);
         if ($exitCode !== 0){
-            throw new \Liip\RMT\Exception('Error while executing git command: '.$cmd);
+            throw new \Liip\RMT\Exception('Error while executing git command: '.$cmd . "\n" . implode("\n", $result));
         }
         return $result;
     }
 }
-


### PR DESCRIPTION
without outputting the command output, you can't really know what is going on even with --verbose

btw, i tried to have the configuration file for rmt in release/ - that does not work as then git commands are executed in the context of release/ so `git add --all` does nothing. when i set the root directory to my real project root, the configuration file is no longer found. maybe we could make this a bit more DI style. like optionally pass config file name in the constructor of Application... wdyt?
