### PR TITLE
Add support for "hidden" responses

### DIFF
--- a/src/Liip/RMT/Command/BaseCommand.php
+++ b/src/Liip/RMT/Command/BaseCommand.php
@@ -113,6 +113,16 @@ abstract class BaseCommand extends Command
     {
         /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
+
+        if ($question->isHiddenAnswer()) {
+            return $dialog->askHiddenResponseAndValidate(
+                $this->getOutput(),
+                $question->getFormatedText(),
+                $question->getValidator(),
+                false
+            );
+        }
+
         return $dialog->askAndValidate(
             $this->getOutput(),
             $question->getFormatedText(),

--- a/src/Liip/RMT/Information/InformationRequest.php
+++ b/src/Liip/RMT/Information/InformationRequest.php
@@ -20,7 +20,8 @@ class InformationRequest
         'interactive' => true,
         'default' => null,
         'interactive_help' => '',
-        'interactive_help_shortcut' => 'h'
+        'interactive_help_shortcut' => 'h',
+        'hidden_answer' => false,
     );
 
     protected $name;

--- a/src/Liip/RMT/Information/InteractiveQuestion.php
+++ b/src/Liip/RMT/Information/InteractiveQuestion.php
@@ -77,6 +77,11 @@ class InteractiveQuestion
         return $default;
     }
 
+    public function isHiddenAnswer()
+    {
+        return $this->informationRequest->getOption('hidden_answer');
+    }
+
     public function getValidator()
     {
         return array($this, 'validate');


### PR DESCRIPTION
We wrote a couple of action classes that need passwords as interactive information requests.  This adds support for such.  Default values not supported
