### PR TITLE
Add support for the name of the remote to push changes to

### DIFF
--- a/src/Liip/RMT/Action/VcsPublishAction.php
+++ b/src/Liip/RMT/Action/VcsPublishAction.php
@@ -17,11 +17,14 @@ class VcsPublishAction extends BaseAction
             return;
         }
 
-        Context::get('vcs')->publishChanges();
+        $remote = Context::get('information-collector')->getValueFor('remote');
+
+        Context::get('vcs')->publishChanges($remote);
         Context::get('vcs')->publishTag(
             Context::get('version-persister')->getTagFromVersion(
                 Context::getParam('new-version')
-            )
+            ),
+            $remote
         );
 
         $this->confirmSuccess();
@@ -34,6 +37,11 @@ class VcsPublishAction extends BaseAction
                 'description' => 'Changes will be published automatically',
                 'type' => 'yes-no',
                 'default' => 'yes'
+            )),
+            new InformationRequest('remote', array(
+                'description' => 'Remote to push changes',
+                'type' => 'text',
+                'default' => 'origin'
             ))
         );
     }

--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -58,14 +58,14 @@ class Git extends BaseVCS
         return $this->executeGitCommand("tag $tagName");
     }
 
-    public function publishTag($tagName)
+    public function publishTag($tagName, $remote = 'origin')
     {
-        $this->executeGitCommand("push origin $tagName");
+        $this->executeGitCommand("push $remote $tagName");
     }
 
-    public function publishChanges()
+    public function publishChanges($remote = 'origin')
     {
-        $this->executeGitCommand("push origin ".$this->getCurrentBranch());
+        $this->executeGitCommand("push $remote ".$this->getCurrentBranch());
     }
 
     public function saveWorkingCopy($commitMsg='')

--- a/src/Liip/RMT/VCS/Hg.php
+++ b/src/Liip/RMT/VCS/Hg.php
@@ -44,14 +44,14 @@ class Hg extends BaseVCS
         return $this->executeHgCommand("tag $tagName");
     }
 
-    public function publishTag($tagName)
+    public function publishTag($tagName, $remote = null)
     {
         // nothing to do, tags are published with other changes
     }
 
-    public function publishChanges()
+    public function publishChanges($remote = 'default')
     {
-        $this->executeHgCommand("push default");
+        $this->executeHgCommand("push $remote");
     }
 
     public function saveWorkingCopy($commitMsg='')

--- a/src/Liip/RMT/VCS/VCSInterface.php
+++ b/src/Liip/RMT/VCS/VCSInterface.php
@@ -24,10 +24,10 @@ interface VCSInterface
 
     /**
      * Publish a new created tag
-     * @param $tagName
+     * @param string $tagName
+     * @param string|null $remote
      */
-    public function publishTag($tagName);
-
+    public function publishTag($tagName, $remote = null);
 
     /**
      * Return the list of all modifications from the given tag until now
@@ -62,6 +62,6 @@ interface VCSInterface
     /**
      * Publish local modification
      */
-    public function publishChanges();
+    public function publishChanges($remote = null);
 }
 


### PR DESCRIPTION
Some of our team members don't use 'origin' as the name of their remote.  This PR asks the user the question of which remote they'd like to push changes and tags to.
