### PR TITLE
BaseAction has a protected options field

### DIFF
--- a/src/Liip/RMT/Action/UpdateVersionClassAction.php
+++ b/src/Liip/RMT/Action/UpdateVersionClassAction.php
@@ -23,14 +23,12 @@ use Liip\RMT\Config\Exception as ConfigException;
  */
 class UpdateVersionClassAction extends BaseAction
 {
-    private $options;
-
     public function __construct($options)
     {
         if (!isset($options['class'])) {
             throw new ConfigException('You must specify the class to update');
         }
-        $this->options = $options;
+        parent::__construct($options);
     }
 
     public function execute()


### PR DESCRIPTION
a8b875b5 added a protected field to the BaseAction, which breaks UpdateVersionClassAction as it defined options as private.

PHP Fatal error:  Access level to Liip\RMT\Action\UpdateVersionClassAction::$options must be protected (as in class Liip\RMT\Action\BaseAction) or weaker in /home/david/liip/symfony-cmf/doctrine/phpcr-odm/vendor/liip/rmt/src/Liip/RMT/Action/UpdateVersionClassAction.php on line 52
