### PR TITLE
Updated semver to stable release, fixes #74

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/console": "~2.0",
         "symfony/yaml": "~2.0",
         "symfony/process": "~2.0",
-        "vierbergenlars/php-semver": "3.0.0-rc2"
+        "vierbergenlars/php-semver": "~3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Follow up for PR #73 and issue #74

Please tag a new version after this is merged, because the current 1.1.0 release can't be used in a composer with minimum-stability: stable (unless you specify a stability flag)

Thanks!
