### PR TITLE
Added exclude merge commits option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Actions can be used for pre or post release parts.
       changelog file (default: *false*)
     * Option `insert-at`: only for addTop formatter: Number of lines to skip from the
       top of the changelog file before adding the release number (default: *0*)
+    * Option `exclude-merge-commits`: Exclude merge commits from the changelog (default: *false*)
 * `vcs-commit`: commit all files of the working copy (only use it with the
   `working-copy-check` prerequisite)
     * Option `commit-message`: specify a custom commit message. %version% will be replaced by the current / next version strings.

--- a/src/Liip/RMT/Action/ChangelogUpdateAction.php
+++ b/src/Liip/RMT/Action/ChangelogUpdateAction.php
@@ -24,6 +24,7 @@ class ChangelogUpdateAction extends BaseAction
     {
         $this->options = array_merge(array(
             'dump-commits' => false,
+            'exclude-merge-commits' => false,
             'format' => 'simple',
             'file' => 'CHANGELOG'
         ), $options);
@@ -36,7 +37,8 @@ class ChangelogUpdateAction extends BaseAction
             try {
                 $extraLines = Context::get('vcs')->getAllModificationsSince(
                     Context::get('version-persister')->getCurrentVersionTag(),
-                    false
+                    false,
+                    $this->options['exclude-merge-commits']
                 );
                 $this->options['extra-lines'] = $extraLines;
             } catch (NoReleaseFoundException $e) {

--- a/src/Liip/RMT/Command/ChangesCommand.php
+++ b/src/Liip/RMT/Command/ChangesCommand.php
@@ -11,6 +11,7 @@
 namespace Liip\RMT\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Liip\RMT\Context;
 
@@ -24,13 +25,16 @@ class ChangesCommand extends BaseCommand
         $this->setName('changes');
         $this->setDescription('Shows the list of changes since last release');
         $this->setHelp('The <comment>changes</comment> command is used to list the changes since last release.');
+        $this->addOption('exclude-merge-commits', null, InputOption::VALUE_NONE, 'Exclude merge commits');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $lastVersion = Context::get('version-persister')->getCurrentVersionTag();
+        $noMerges = $input->getOption('exclude-merge-commits');
+
         $output->writeln("Here is the list of changes since <green>$lastVersion</green>:");
         $output->indent();
-        $output->writeln(Context::get('vcs')->getAllModificationsSince($lastVersion));
+        $output->writeln(Context::get('vcs')->getAllModificationsSince($lastVersion, false, $noMerges));
     }
 }

--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -34,9 +34,9 @@ class Git extends BaseVCS
     */
     protected $dryRun = false;
 
-    public function getAllModificationsSince($tag, $color=true)
+    public function getAllModificationsSince($tag, $color = true, $noMergeCommits = false)
     {
-        return $this->executeGitCommand("log --oneline $tag..HEAD ".($color?'--color=always':''));
+        return $this->executeGitCommand("log --oneline $tag..HEAD " . ($color?'--color=always':'') . ($noMergeCommits ? '--no-merges' : ''));
     }
 
     public function getModifiedFilesSince($tag)

--- a/src/Liip/RMT/VCS/Hg.php
+++ b/src/Liip/RMT/VCS/Hg.php
@@ -14,9 +14,9 @@ class Hg extends BaseVCS
 {
     protected $dryRun = false;
 
-    public function getAllModificationsSince($tag, $color=true)
+    public function getAllModificationsSince($tag, $color=true, $noMergeCommits = false)
     {
-        $modifications = $this->executeHgCommand("log --template '{node|short} {desc}\n' -r tip:$tag");
+        $modifications = $this->executeHgCommand("log --template '{node|short} {desc}\n' -r tip:$tag" . ($noMergeCommits ? '--no-merges' : ''));
         array_pop($modifications); // remove the last commit since it is the one described by the tag
 
         return $modifications;

--- a/src/Liip/RMT/VCS/VCSInterface.php
+++ b/src/Liip/RMT/VCS/VCSInterface.php
@@ -40,10 +40,11 @@ interface VCSInterface
      * Return the list of all modifications from the given tag until now
      * @param string $tag
      * @param bool   $color
+     * @param bool   $noMergeCommits
      *
      * @return array
      */
-    public function getAllModificationsSince($tag, $color = true);
+    public function getAllModificationsSince($tag, $color = true, $noMergeCommits = false);
 
     /**
      * Return the list of all modified files from the given tag until now
@@ -64,7 +65,7 @@ interface VCSInterface
     /**
      * Save the local modifications (commit)
      * @param $commitMsg
-     * 
+     *
      * @return mixed
      */
     public function saveWorkingCopy($commitMsg = '');

--- a/test/Liip/RMT/Tests/Unit/VCS/GitTest.php
+++ b/test/Liip/RMT/Tests/Unit/VCS/GitTest.php
@@ -98,6 +98,36 @@ class GitTest extends \PHPUnit_Framework_TestCase
         $vcs->getCurrentBranch();
     }
 
+    public function testChangeNoMergeCommits()
+    {
+        $vcs = new Git();
+        exec("git checkout -b merge-branch --quiet");
+        exec('echo "text" > new-file && git add -A && git commit -m "First commit"');
+        exec('git checkout master --quiet');
+        exec('git merge --no-ff merge-branch');
+
+        $modifs = $vcs->getAllModificationsSince('1.1.0', false, true);
+
+        $this->assertContains("First commit", $modifs[0]);
+        $this->assertContains("Add a third file", $modifs[1]);
+        $this->assertContains("Modification of the first file", $modifs[2]);
+    }
+
+    public function testChangeWithMergeCommits()
+    {
+        $vcs = new Git();
+        exec("git checkout -b merge-branch --quiet");
+        exec('echo "text" > new-file && git add -A && git commit -m "First commit"');
+        exec('git checkout master --quiet');
+        exec('git merge --no-ff merge-branch');
+
+        $modifs = $vcs->getAllModificationsSince('1.1.0');
+
+        $this->assertContains("Merge branch 'merge-branch'", $modifs[0]);
+        $this->assertContains("First commit", $modifs[1]);
+        $this->assertContains("Add a third file", $modifs[2]);
+        $this->assertContains("Modification of the first file", $modifs[3]);
+    }
 
     protected function tearDown()
     {


### PR DESCRIPTION
Added a exclude-merge-commits for the changelog-update and also added this option for the ./RMT changes command. This way you can have a clean changelog without all the merge commits. 
Fixes #80 

I only need some help with the hg tests, because i have no experience with mercurial. So if someone else could create a PR for these extra tests would be nice!
