### PR TITLE
Fixed info tag in title

### DIFF
--- a/src/Liip/RMT/Command/InitCommand.php
+++ b/src/Liip/RMT/Command/InitCommand.php
@@ -171,7 +171,7 @@ class InitCommand extends BaseCommand
         file_put_contents($this->configPath, $config);
 
         // Confirmation
-        $this->getOutput()->writeBigTitle('Success, you can start using RMT by calling <info>RMT release</info>');
+        $this->getOutput()->writeBigTitle('Success, you can start using RMT by calling "RMT release"');
         $this->getOutput()->writeEmptyLine();
     }
 


### PR DESCRIPTION
I've came across this issue when initializing a new repo with RMT. In the result message of the init command we used info tags in the title and the were not parsed. So removed the tags and added quotes

Before:
![before](http://i.imgur.com/mGgP80C.png)
After:
![after](http://i.imgur.com/urnT3p0.png)
