### PR TITLE
Allow namespaced and autoloaded custom actions

### DIFF
--- a/src/Liip/RMT/Config/Handler.php
+++ b/src/Liip/RMT/Config/Handler.php
@@ -179,6 +179,12 @@ class Handler
                 throw new \Liip\RMT\Exception("Impossible to open [$file] please review your config");
             }
         }
+        elseif (strpos($name, '\\') !== false ) {
+            // If the name contains a backslash, assume it's a full namespaced class and load it as-is
+            // If the class has no namespace, it can be prefixed with a backslash to trigger this behaviour
+
+            return $name;
+        }
 
         return $this->findInternalClass($name, $sectionName);
     }

--- a/src/Liip/RMT/Config/Handler.php
+++ b/src/Liip/RMT/Config/Handler.php
@@ -24,6 +24,7 @@ class Handler
     public function getDefaultConfig()
     {
         return array(
+            "bootstrap" => null,
             "vcs" => null,
             "prerequisites" => array(),
             "pre-release-actions" => array(),
@@ -82,6 +83,11 @@ class Handler
     {
         // Validate the config entry
         $this->validateRootElements($config);
+
+        // Load the bootstrap file if present
+        if ($config['bootstrap'] !== null) {
+            require $this->projectRoot.DIRECTORY_SEPARATOR.$config['bootstrap'];
+        }
 
         // For single value elements, normalize all class name and options, remove null entry
         foreach (array("vcs", "version-generator", "version-persister") as $configKey) {

--- a/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
+++ b/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
@@ -135,6 +135,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
 
         $this->assertEquals($method->invokeArgs($configHandler, array()), array(
+            'bootstrap' => null,
             'vcs' => null,
             'prerequisites' => array(),
             'pre-release-actions' => array(),
@@ -143,6 +144,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
             'version-persister' => 'foo',
         ));
         $this->assertEquals($method->invokeArgs($configHandler, array('dev')), array(
+            'bootstrap' => null,
             'vcs' => null,
             'prerequisites' => array(),
             'pre-release-actions' => array(),
@@ -168,6 +170,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
 
         $this->assertEquals($method->invokeArgs($configHandler, array()), array(
+            'bootstrap' => null,
             'vcs' => null,
             'prerequisites' => array(),
             'pre-release-actions' => array(),
@@ -176,6 +179,7 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
             'version-persister' => 'foo',
         ));
         $this->assertEquals($method->invokeArgs($configHandler, array('dev')), array(
+            'bootstrap' => null,
             'vcs' => null,
             'prerequisites' => array(),
             'pre-release-actions' => array(),

--- a/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
+++ b/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
@@ -221,7 +221,19 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
             array('vcs', array('name' => 'git'), 'Liip\RMT\VCS\Git', array()),
             // vcs: {name: git, opt1: val1}
             array('vcs', array('name' => 'git', 'opt1' => 'val1'), 'Liip\RMT\VCS\Git', array('opt1' => 'val1')),
-            array('prerequisites_1', 'vcs-clean-check', 'Liip\RMT\Prerequisite\VcsCleanCheck', array())
+            array('prerequisites_1', 'vcs-clean-check', 'Liip\RMT\Prerequisite\VcsCleanCheck', array()),
+            // vcs: Foo\Bar
+            array('vcs', 'Foo\Bar', 'Foo\Bar', array()),
+            // vcs: Foo
+            array('vcs', 'Foo', 'Liip\RMT\VCS\Foo', array()),
+            // vcs: \Foo
+            array('vcs', '\Foo', '\Foo', array()),
+            // pre-release-actions: Foo\Bar
+            array('pre-release-actions', 'Foo\Bar', 'Foo\Bar', array()),
+            // pre-release-actions: Foo
+            array('pre-release-actions', 'Foo', 'Liip\RMT\Action\FooAction', array()),
+            // pre-release-actions: \Foo
+            array('pre-release-actions', '\Foo', '\Foo', array())
         );
     }
 }


### PR DESCRIPTION
With this PR, when specifying prerequisites and actions, names containing a backslash are treated as full class names, and thus are not prefixed by the internal namespaces, nor suffixed by type. This allows to use:

- classes from the current project if RMT is installed as a Composer dependency;
- globally installed classes if RMT is installed globally with Composer.

Moreover, inspired by PHPUnit’s `bootstrap` parameter, a bootstrap script can be specified in the configuration. This allows, for example, to use classes from the current project if RMT is installed globally and the project has an autoloader. Typically:

```yaml
_default:
    bootstrap: vendor/autoload.php
    # ...
```

Tests are included for the configuration merging and class resolution features of `Config\Handler`.

The use cases for me are:

- being able to write generic custom prerequisites and actions and installing them globally to use in many projects;
- being able to write project-specific prerequisites and actions in projects that use Composer and having them follow the same namespace and autoloading conventions as the project.

I think this PR does the trick, but I may have missed something. I’ll be glad to receive feedback about it.