### PR TITLE
Add action to edit any type of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,20 @@ Actions can be used for pre or post release parts.
     * Option `commit-message`: specify a custom commit message. %version% will be replaced by the current / next version strings.
 * `vcs-tag`: Tag the last commit
 * `vcs-publish`: Publish the changes (commits and tags)
-* `composer-update`: Update the version number in a composer file
-* `update-version-class`: Update the version constant in a class file.
-    * Option `class`: path to class to be updated, or fully qualified class name of the class containing the version constant
+* `update-file`: Update the version number in a file
+    * Option `file`: path to be updated
+    * Option `pattern`: optional, use to specify the string replacement pattern in your
+      version file. %version% will be replaced by the current / next version strings.
+      For example you could use `const VERSION = '%version%';`. If you do not specify
+      this option, every occurrence of the version string in the file will be replaced.
+* `update-class`: Update a version number in the file of a given PHP class
+    * Option `class`: fully qualified class name of the class containing the version constant
     * Option `pattern`: optional, use to specify the string replacement pattern in your
       version class. %version% will be replaced by the current / next version strings.
       For example you could use `const VERSION = '%version%';`. If you do not specify
       this option, every occurrence of the version string in the file will be replaced.
+* `update-version-class`: Deprecated: use `update-class` or `update-file` instead.
+* `composer-update`: Update the version number in your project composer.json file
 * `build-phar-package`: Builds a Phar package of the current project whose filename depends on the 'package-name' option and the deployed version: [package-name]-[version].phar
     * Option `package-name`: the name of the generate package
     * Option `destination`: the destination directory to build the package into. If prefixed with a slash, is considered absolute, otherwise relative to the project root.

--- a/src/Liip/RMT/Action/ComposerUpdateAction.php
+++ b/src/Liip/RMT/Action/ComposerUpdateAction.php
@@ -12,22 +12,26 @@
 namespace Liip\RMT\Action;
 
 use Liip\RMT\Context;
+use Liip\RMT\Exception;
 
 /**
- * Update the version in composer.json
+ * An updater that updates the version information stored in any kind of file.
+ *
+ * This file could be a configuration file (yml, json) or a package.json file
+ * for instance.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
  */
-class ComposerUpdateAction extends \Liip\RMT\Action\BaseAction
+class ComposerUpdateAction extends UpdateFileAction
 {
     public function execute()
     {
-        $newVersion = Context::getParam('new-version');
         $composerFile = Context::getParam('project-root').'/composer.json';
-        if (!file_exists($composerFile)) {
-            throw new \Liip\RMT\Exception("Impossible to file the composer file ($composerFile)");
+
+        if (! file_exists($composerFile)) {
+            throw new Exception(sprintf('Composer file not found (searched at %s)', $composerFile));
         }
-        $fileContent = file_get_contents($composerFile);
-        $fileContent = preg_replace('/("version":[^,]*,)/', '"version": "'.$newVersion.'",', $fileContent);
-        file_put_contents($composerFile, $fileContent);
-        $this->confirmSuccess();
+
+        $this->updateFile($composerFile, '"version": "%version%"');
     }
 }

--- a/src/Liip/RMT/Action/UpdateClassAction.php
+++ b/src/Liip/RMT/Action/UpdateClassAction.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the project RMT
+ *
+ * Copyright (c) 2013, Liip AG, http://www.liip.ch
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\RMT\Action;
+
+use Liip\RMT\Context;
+use Liip\RMT\Exception;
+use Liip\RMT\Config\Exception as ConfigException;
+
+/**
+ * An updater that updates the version information stored in a PHP file (found by its class).
+ *
+ * Typically this would be a class defining a constant for client code to check
+ * the version of the library they are using.
+ *
+ * An example Version class might look like this:
+ *
+ * class Version
+ * {
+ *     const VERSION = '1.0.0-beta-4';
+ * }
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class UpdateClassAction extends UpdateFileAction
+{
+    public function execute()
+    {
+        if (! isset($this->options['class'])) {
+            throw new ConfigException('You must specify the class to update');
+        }
+
+        $this->updateClass(
+            $this->options['class'],
+            isset($this->options['pattern']) ? $this->options['pattern'] : null
+        );
+    }
+
+    protected function updateClass($class, $pattern = null)
+    {
+        // see http://php.net/manual/en/language.oop5.basic.php for the regex
+        if (! preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $class)) {
+            throw new Exception('Configuration value "'. $class .'" is not a valid class name');
+        }
+
+        /*
+         * If the class is not available in current context, we
+         * try to load Composer autoloader in order to find it.
+         */
+        if (! class_exists($class)) {
+            $loaderFile = $this->loadProjectComposerAutoload();
+
+            // Not able to find Composer autoloader
+            if (! $loaderFile) {
+                throw new Exception(sprintf(
+                    'Class %s not found (Composer autoloader was not found)',
+                    $class
+                ));
+            }
+
+            // Still doesn't exist after Composer loaded
+            if (! class_exists($class)) {
+                throw new Exception(sprintf(
+                    'Class %s not found (Composer autoloader was found: %s)',
+                    $class,
+                    $loaderFile
+                ));
+            }
+        }
+
+        $reflection = new \ReflectionClass($class);
+        $filename = $reflection->getFileName();
+
+        $this->updateFile($filename, $pattern);
+    }
+
+    /**
+     * @return string|null
+     */
+    private function loadProjectComposerAutoload()
+    {
+        $root = Context::getParam('project-root');
+
+        $autoload = [
+            $root.'/vendor/autoload.php',
+            $root.'/../vendor/autoload.php',
+            $root.'/../../autoload.php',
+        ];
+
+        foreach ($autoload as $file) {
+            if (file_exists($file)) {
+                require $file;
+                return $file;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Liip/RMT/Action/UpdateFileAction.php
+++ b/src/Liip/RMT/Action/UpdateFileAction.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the project RMT
+ *
+ * Copyright (c) 2013, Liip AG, http://www.liip.ch
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\RMT\Action;
+
+use Liip\RMT\Context;
+use Liip\RMT\Exception;
+use Liip\RMT\Config\Exception as ConfigException;
+
+/**
+ * An updater that updates the version information stored in any kind of file.
+ *
+ * This file could be a configuration file (yml, json) or a package.json file
+ * for instance.
+ *
+ * @author Titouan Galopin <galopintitouan@gmail.com>
+ */
+class UpdateFileAction extends BaseAction
+{
+    public function execute()
+    {
+        if (! isset($this->options['file'])) {
+            throw new ConfigException('You must specify the file to update');
+        }
+
+        $this->updateFile(
+            $this->options['file'],
+            isset($this->options['pattern']) ? $this->options['pattern'] : null
+        );
+    }
+
+    protected function updateFile($filename, $pattern = null)
+    {
+        $current = Context::getParam('current-version');
+        $next = Context::getParam('new-version');
+
+        if (! file_exists($filename)) {
+            throw new Exception('The path ' . $filename . ' does not exists');
+        }
+
+        if (! is_file($filename)) {
+            throw new Exception('The path ' . $filename . ' must be a file');
+        }
+
+        $content = file_get_contents($filename);
+
+        if (false === strpos($content, $current)) {
+            throw new Exception('The file ' . $filename . ' does not contains the current version ' . $current);
+        }
+
+        if ($pattern) {
+            $current = str_replace('%version%', $current, $pattern);
+            $next = str_replace('%version%', $next, $pattern);
+        }
+
+        $content = str_replace($current, $next, $content);
+
+        if (false === strpos($content, $next) || @file_put_contents($filename, $content) === false) {
+            throw new Exception('The file ' . $filename . ' could not be updated with version ' . $next);
+        }
+
+        $this->confirmSuccess();
+    }
+}

--- a/src/Liip/RMT/Changelog/Formatter/AddTopChangelogFormatter.php
+++ b/src/Liip/RMT/Changelog/Formatter/AddTopChangelogFormatter.php
@@ -46,6 +46,7 @@ class AddTopChangelogFormatter
         if (!empty($comment)) {
             array_splice($lines, $pos, 0, array($comment, ''));
         }
+        
         if (isset($options['extra-lines'])) {
             array_splice($lines, $pos, 0, $options['extra-lines']);
         }

--- a/src/Liip/RMT/Changelog/Formatter/CustomChangelogFormatter.php
+++ b/src/Liip/RMT/Changelog/Formatter/CustomChangelogFormatter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Liip\RMT\Changelog\Formatter;
+
+/**
+ * @author Titouan Galopin
+ */
+class CustomChangelogFormatter
+{
+    public function updateExistingLines($lines, $version, $comment, $options)
+    {
+        $newLines = [];
+        $newLines[] = '* '.$version.' ('.date('Y-m-d').')';
+        
+        if (isset($options['extra-lines'])) {
+            $newLines[] = '';
+
+            foreach ($options['extra-lines'] as $extraLine) {
+                $newLines[] = ' * '.$extraLine;
+            }
+        }
+
+        $newLines[] = '';
+
+        foreach ($lines as $line) {
+            $newLines[] = $line;
+        }
+
+        return $newLines;
+    }
+}


### PR DESCRIPTION
In some cases, the usage of `UpdateVersionClass` is not possible as we are dealing with yaml, xml, json, etc. Many different types of configuration exist and this PR aims to provide a generic updater for other types than PHP.

I have two personnal use-cases but I think there are many others:
- working on https://github.com/tgalopin/puli.js, I would like to update my `package.json` on releasing
- working on Symfony applications, I would like to update my assets version (in `app/config/config.yml`) witohut having to use a PHP class

This PR is based on the UpdateVersionClass action, by @dbu :) .