### PR TITLE
add support for commit and tag gpg-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Configuration examples
 ----------------------
 Most of the time, it will be easier for you to pick up and example bellow and to adapt it to your needs.
 
-### No VCS, changelog updater onlyls 
+### No VCS, changelog updater only
 
     version-generator: semantic
     version-persister: changelog

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Configuration examples
 ----------------------
 Most of the time, it will be easier for you to pick up and example bellow and to adapt it to your needs.
 
-### No VCS, changelog updater only
+### No VCS, changelog updater onlyls 
 
     version-generator: semantic
     version-persister: changelog
@@ -229,6 +229,17 @@ Most of the time, it will be easier for you to pick up and example bellow and to
     version-generator: simple
     version-persister: vcs-tag
     prerequisites: [working-copy-check, display-last-changes]
+    
+### Using Git tags, simple versioning and prerequisites, and gpg sign commit and tags
+
+    vcs: 
+      name: git
+      sign-tag: true
+      sign-commit: true
+    version-generator: simple
+    version-persister: vcs-tag
+    prerequisites: [working-copy-check, display-last-changes]
+
 
 ### Using Git tags with prefix, semantic versioning and pushing automatically
 

--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -48,10 +48,8 @@ class Git extends BaseVCS
     public function createTag($tagName)
     {
         // this requires git and gpg configured
-        if (isset($this->options['sign-tag']) && $this->options['sign-tag']) {
-            return $this->executeGitCommand("tag -s $tagName -m $tagName");
-        }
-        return $this->executeGitCommand("tag $tagName");
+        $signOption = (isset($this->options['sign-tag']) && $this->options['sign-tag']) ? '-s' : '';
+        return $this->executeGitCommand("tag $signOption $tagName -m $tagName");
     }
 
     public function publishTag($tagName, $remote = null)
@@ -70,13 +68,10 @@ class Git extends BaseVCS
     {
         $this->executeGitCommand('add --all');
 
+        $signOption = (isset($this->options['sign-tag']) && $this->options['sign-tag']) ? '-S' : '';
+
         // this requires git and gpg configured
-        if (isset($this->options['sign-commit']) && $this->options['sign-commit'])
-        {
-            $this->executeGitCommand("commit -S -m \"$commitMsg\"");
-            return;
-        }
-        $this->executeGitCommand("commit -m \"$commitMsg\"");
+        $this->executeGitCommand("commit $signOption -m \"$commitMsg\"");
     }
 
     public function getCurrentBranch()

--- a/src/Liip/RMT/VCS/Git.php
+++ b/src/Liip/RMT/VCS/Git.php
@@ -47,6 +47,10 @@ class Git extends BaseVCS
 
     public function createTag($tagName)
     {
+        // this requires git and gpg configured
+        if (isset($this->options['sign-tag']) && $this->options['sign-tag']) {
+            return $this->executeGitCommand("tag -s $tagName -m $tagName");
+        }
         return $this->executeGitCommand("tag $tagName");
     }
 
@@ -65,6 +69,13 @@ class Git extends BaseVCS
     public function saveWorkingCopy($commitMsg = '')
     {
         $this->executeGitCommand('add --all');
+
+        // this requires git and gpg configured
+        if (isset($this->options['sign-commit']) && $this->options['sign-commit'])
+        {
+            $this->executeGitCommand("commit -S -m \"$commitMsg\"");
+            return;
+        }
         $this->executeGitCommand("commit -m \"$commitMsg\"");
     }
 


### PR DESCRIPTION
since github now supports gpg singed commits, i figure this is a useful addition.
by default nothing changes, however if you change the vcs config, 

so it has the options sign-tag and sign-commit set, it will add the -s (tag) or -S (commit) option, so git will try to tag it.

there is no test included, since this is basically just passing through an option and tests would fail for everyone who has not setup gpg and git for this.