### PR TITLE
Allow specification of tests check command timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Prerequisite actions are executed before the interactive part.
 * `display-last-changes`: display your last changes
 * `tests-check`: run the project test suite
   * Option `command`: command to run (default: *phpunit*)
+  * Option `timeout`: the number of seconds after which the command times out (default: *60.0*)
   * Option `expected_exit_code`: expected return code (default: *0*)
 * `composer-json-check`: run a validate on the composer.json
   * Option `composer`: how to run composer (default: *php composer.phar*)

--- a/src/Liip/RMT/Action/BaseAction.php
+++ b/src/Liip/RMT/Action/BaseAction.php
@@ -62,12 +62,18 @@ abstract class BaseAction
 
     /**
      * Execute a command and render the output through the classical indented output
-     * @param $cmd
+     * @param string $cmd
+     * @param float|null $timeout
      * @return Process
      */
-    public function executeCommandInProcess($cmd){
+    public function executeCommandInProcess($cmd, $timeout = null){
         Context::get('output')->write("<comment>$cmd</comment>\n\n");
         $process = new Process($cmd);
+
+        if ($timeout !== null) {
+            $process->setTimeout($timeout);
+        }
+
         $process->run(function ($type, $buffer) {
             Context::get('output')->write($buffer);
         });

--- a/src/Liip/RMT/Prerequisite/TestsCheck.php
+++ b/src/Liip/RMT/Prerequisite/TestsCheck.php
@@ -40,7 +40,8 @@ class TestsCheck extends BaseAction
         }
 
         // Run the tests and live output with the standard output class
-        $process = $this->executeCommandInProcess($this->options['command']);
+        $timeout = isset($this->options['timeout']) ? $this->options['timeout'] : null;
+        $process = $this->executeCommandInProcess($this->options['command'], $timeout);
 
         // Break up if the result is not good
         if ($process->getExitCode() !== $this->options['expected_exit_code']) {

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Liip\RMT\Tests\Functional;
+
+use Exception;
+use Liip\RMT\Context;
+use Liip\RMT\Prerequisite\TestsCheck;
+
+class TestsCheckTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $informationCollector = $this->createMock('Liip\RMT\Information\InformationCollector');
+        $informationCollector->method('getValueFor')->with(TestsCheck::SKIP_OPTION)->willReturn(false);
+
+        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $output->method('write');
+
+        $context = Context::getInstance();
+        $context->setService('information-collector', $informationCollector);
+        $context->setService('output', $output);
+    }
+
+    /** @test */
+    public function succeeds_when_command_finished_within_the_default_configured_timeout_of_60s()
+    {
+        $check = new TestsCheck(['command' => 'echo OK']);
+        $check->execute();
+    }
+
+    /** @test */
+    public function succeeds_when_command_finished_within_configured_timeout()
+    {
+        $check = new TestsCheck(['command' => 'echo OK', 'timeout' => 0.100]);
+        $check->execute();
+    }
+
+    /** @test */
+    public function fails_when_the_command_exceeds_the_timeout()
+    {
+        $this->setExpectedException(Exception::class, 'exceeded the timeout');
+
+        $check = new TestsCheck(['command' => 'sleep 1', 'timeout' => 0.100]);
+        $check->execute();
+    }
+}

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -38,7 +38,7 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function fails_when_the_command_exceeds_the_timeout()
     {
-        $this->setExpectedException(Exception::class, 'exceeded the timeout');
+        $this->setExpectedException('Exception', 'exceeded the timeout');
 
         $check = new TestsCheck(['command' => 'sleep 1', 'timeout' => 0.100]);
         $check->execute();

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -38,7 +38,7 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function fails_when_the_command_exceeds_the_timeout()
     {
-        $this->setExpectedException('Exception', 'exceeded the timeout');
+        $this->setExpectedExceptionRegExp('Exception', 'process.*time.*out');
 
         $check = new TestsCheck(array('command' => 'sleep 1', 'timeout' => 0.100));
         $check->execute();

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -24,14 +24,14 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function succeeds_when_command_finished_within_the_default_configured_timeout_of_60s()
     {
-        $check = new TestsCheck(['command' => 'echo OK']);
+        $check = new TestsCheck(array('command' => 'echo OK'));
         $check->execute();
     }
 
     /** @test */
     public function succeeds_when_command_finished_within_configured_timeout()
     {
-        $check = new TestsCheck(['command' => 'echo OK', 'timeout' => 0.100]);
+        $check = new TestsCheck(array('command' => 'echo OK', 'timeout' => 0.100));
         $check->execute();
     }
 
@@ -40,7 +40,7 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Exception', 'exceeded the timeout');
 
-        $check = new TestsCheck(['command' => 'sleep 1', 'timeout' => 0.100]);
+        $check = new TestsCheck(array('command' => 'sleep 1', 'timeout' => 0.100));
         $check->execute();
     }
 }

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -10,10 +10,10 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        $informationCollector = $this->createMock('Liip\RMT\Information\InformationCollector');
+        $informationCollector = $this->getMock('Liip\RMT\Information\InformationCollector');
         $informationCollector->method('getValueFor')->with(TestsCheck::SKIP_OPTION)->willReturn(false);
 
-        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->getMock('Symfony\Component\Console\Output\OutputInterface');
         $output->method('write');
 
         $context = Context::getInstance();

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -38,7 +38,7 @@ class TestsCheckTest extends \PHPUnit_Framework_TestCase
     /** @test */
     public function fails_when_the_command_exceeds_the_timeout()
     {
-        $this->setExpectedExceptionRegExp('Exception', 'process.*time.*out');
+        $this->setExpectedExceptionRegExp('Exception', '~process.*time.*out~');
 
         $check = new TestsCheck(array('command' => 'sleep 1', 'timeout' => 0.100));
         $check->execute();


### PR DESCRIPTION
We currently execute a test suite in a project that sometimes exceeds the default Symfony Process component's timeout of 60 seconds. Are you by chance interested in the following change? Another solution would be to have no timeout at all.

This PR adds the `timeout` option to the `tests-check` prerequisite. The default is still 60.0 seconds, after which the Symfony Process component throws an exception.

Can squash it into one commit if you'd like.