### PR TITLE
Use require instead of require_once for global composer install

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -17,7 +17,7 @@ if (extension_loaded('phar') && method_exists('Phar', 'running') && file_exists(
 } elseif (file_exists($file = __DIR__ . '/../../autoload.php')) {
 
     // Composer standard location
-    $loader = require_once $file;
+    $loader = require $file;
     $loader->add('Liip\RMT\Tests', __DIR__ . '/test');
     $loader->add('Liip', __DIR__ . '/src');
 } elseif (file_exists($file = __DIR__ . '/vendor/autoload.php')) {


### PR DESCRIPTION
Hello,

Somehow composer loader was already required so that it makes RMT failed.

Anyway it does not look useful to use `require_once` to get composer loader.

```
PHP Fatal error:  Uncaught Error: Call to a member function add() on boolean in /home/benoit/dotfiles/.composer/vendor/liip/rmt/autoload.php:23
Stack trace:
#0 /home/benoit/dotfiles/.composer/vendor/liip/rmt/command.php(2): require_once()
#1 /home/benoit/dotfiles/.composer/vendor/liip/rmt/RMT(6): require('/home/benoit/do...')
#2 {main}
  thrown in /home/benoit/dotfiles/.composer/vendor/liip/rmt/autoload.php on line 23

Fatal error: Uncaught Error: Call to a member function add() on boolean in /home/benoit/dotfiles/.composer/vendor/liip/rmt/autoload.php:23
Stack trace:
#0 /home/benoit/dotfiles/.composer/vendor/liip/rmt/command.php(2): require_once()
#1 /home/benoit/dotfiles/.composer/vendor/liip/rmt/RMT(6): require('/home/benoit/do...')
#2 {main}
  thrown in /home/benoit/dotfiles/.composer/vendor/liip/rmt/autoload.php on line 23
```

Let me know for anything.