### PR TITLE
Generate markdown-compatible changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Actions can be used for pre or post release parts.
 
 * `changelog-update`: Update a changelog file. This action is further configured
   to use a specific formatter.
-    * Option `format`: *simple*, *semantic* or *addTop*  (default: *simple*)
+    * Option `format`: *simple*, *semantic*, *markdown* or *addTop*  (default: *simple*)
     * Option `file`: path from .rmt.yml to changelog file (default: *CHANGELOG*)
     * Option `dump-commits`: write all commit messages since the last release into the
       changelog file (default: *false*)
@@ -269,7 +269,7 @@ Most of the time, it will be easier for you to pick up an example below and adap
         tag-prefix : "v_"
     post-release-actions: [vcs-publish]
 
-### Using semantic versioning on master and simple versioning on topic branches
+### Using semantic versioning on master and simple versioning on topic branches, markdown formatting for changelog
 
     _default:
         vcs: git
@@ -285,7 +285,7 @@ Most of the time, it will be easier for you to pick up an example below and adap
         prerequisites: [working-copy-check, display-last-changes]
         pre-release-actions:
             changelog-update:
-                format: semantic
+                format: markdown
                 file: CHANGELOG.md
                 dump-commits: true
             update-version-class:

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Authors
 
 * Laurent Prodon Liip AG
 * David Jeanmonod Liip AG
-* Peter Petermann Gameforge 4D GmbH
+* Peter Petermann
 * Gilles Crettenand Liip AG
 * and [others contributors](https://github.com/liip/RMT/graphs/contributors)
 

--- a/test/Liip/RMT/Tests/Unit/Changelog/Formatter/MarkdownChangelogFormatter.php
+++ b/test/Liip/RMT/Tests/Unit/Changelog/Formatter/MarkdownChangelogFormatter.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the project RMT
+ *
+ * Copyright (c) 2013, Liip AG, http://www.liip.ch
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\RMT\Tests\Unit\Changelog\Formatter;
+
+class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @return Liip\RMT\Changelog\Formatter\SemanticChangelogFormatter
+     */
+    protected function getFormatter()
+    {
+        $formatter = $this
+            ->getMockBuilder('Liip\RMT\Changelog\Formatter\MarkdownChangelogFormatter')
+            ->setMethods(array('getFormattedDate'))
+            ->getMock()
+        ;
+        $formatter
+            ->expects($this->any())
+            ->method('getFormattedDate')
+            ->will($this->returnValue('1980-11-08 12:34'))
+        ;
+
+        return $formatter;
+    }
+
+    /**
+     * @dataProvider getDataForFirstReleaseTest
+     */
+    public function testFirstRelease($version, $type, $results)
+    {
+        $formatter = $this->getFormatter();
+        $lines = $formatter->updateExistingLines(array(), $version, 'foo bar', array('type' => $type));
+        $this->assertEquals($results, $lines);
+    }
+
+    public function getDataForFirstReleaseTest()
+    {
+        return array(
+            array('0.0.1', 'patch', array('', '## VERSION 0  FOO BAR', '', ' * Version **0.0** - foo bar', '   * 1980-11-08 12:34  **0.0.1**  initial release')),
+            array('0.1.0', 'patch', array('', '## VERSION 0  FOO BAR', '', ' * Version **0.1** - foo bar', '   * 1980-11-08 12:34  **0.1.0**  initial release')),
+            array('1.0.0', 'patch', array('', '## VERSION 1  FOO BAR', '', ' * Version **1.0** - foo bar', '   * 1980-11-08 12:34  **1.0.0**  initial release')),
+        );
+    }
+
+    public function testExtraLines()
+    {
+        $formatter = $this->getFormatter();
+        $lines = $formatter->updateExistingLines(array(
+            '',
+            '## VERSION 1  FOO BAR',
+            '',
+            ' * Version **1.0** - foo bar',
+            '   * 1980-11-08 12:34  **1.0.0**  initial release',
+
+        ), '1.0.1', 'foo bar', array('type' => 'patch', 'extra-lines' => array(
+            'ada96f3 Add new tests for command RMT init and RMT current ref #10',
+            '2eb6fae Documentation review',
+        )));
+
+        $this->assertEquals(array(
+            '',
+            '## VERSION 1  FOO BAR',
+            '',
+            ' * Version **1.0** - foo bar',
+            '   * 1980-11-08 12:34  **1.0.1**  foo bar',
+            '      * ada96f3 Add new tests for command RMT init and RMT current ref #10',
+            '      * 2eb6fae Documentation review',
+            '   * 1980-11-08 12:34  **1.0.0**  initial release',
+        ), $lines);
+    }
+
+    public function testUpdateExistingWithPatch()
+    {
+        $formatter = $this->getFormatter();
+        $lines = $formatter->updateExistingLines(
+            array(
+                '',
+                '## VERSION 1  FOO BAR',
+                '',
+                ' * Version **1.0** - foo bar',
+                '   * 1980-11-08 12:34  **1.0.0**  initial release',
+            ),
+            '1.0.1',
+            'foofoo',
+            array('type' => 'patch')
+        );
+
+        $this->assertEquals(array(
+            '',
+            '## VERSION 1  FOO BAR',
+            '',
+            ' * Version **1.0** - foo bar',
+            '   * 1980-11-08 12:34  **1.0.1**  foofoo',
+            '   * 1980-11-08 12:34  **1.0.0**  initial release',
+        ), $lines);
+    }
+
+    public function testUpdateExistingWithMinor()
+    {
+        $formatter = $this->getFormatter();
+        $lines = $formatter->updateExistingLines(
+            array(
+                '',
+                '## VERSION 1  FOO BAR',
+                '',
+                ' * Version **1.0** - foo bar',
+                '   * 1980-11-08 12:34  **1.0.0**  initial release',
+            ),
+            '1.1.0',
+            'foofoo',
+            array('type' => 'minor')
+        );
+        $this->assertEquals(array(
+            '',
+            '## VERSION 1  FOO BAR',
+            '',
+            ' * Version **1.1** - foofoo',
+            '   * 1980-11-08 12:34  **1.1.0**  initial release',
+            '',
+            ' * Version **1.0** - foo bar',
+            '   * 1980-11-08 12:34  **1.0.0**  initial release',
+        ), $lines);
+    }
+
+    public function testUpdateExistingWithMajor()
+    {
+        $formatter = $this->getFormatter();
+        $lines = $formatter->updateExistingLines(
+            array(
+                '',
+                '## VERSION 1  FOO BAR',
+                '',
+                ' * Version **1.0** - foo bar',
+                '   * 1980-11-08 12:34  **1.0.0**  initial release',
+            ),
+            '2.0.0',
+            'foofoo',
+            array('type' => 'major')
+        );
+
+        $this->assertEquals(array(
+            '',
+            '## VERSION 2  FOOFOO',
+            '',
+            ' * Version **2.0** - foofoo',
+            '   * 1980-11-08 12:34  **2.0.0**  initial release',
+            '',
+            '## VERSION 1  FOO BAR',
+            '',
+            ' * Version **1.0** - foo bar',
+            '   * 1980-11-08 12:34  **1.0.0**  initial release',
+        ), $lines);
+    }
+}


### PR DESCRIPTION
This PullRequest includes two commits: 
 * it implements a requested feature (#138 )
 * it drops the company name next to my name in README.md

example for the generated Markdown of the MarkdownChangelogFormatter:
```markdown
## VERSION 1  MAJOR TITLE

 * Version **1.1** - Minor Title
    * 1980-11-08 12:34  **1.1.1**  patch comment
        * ada96f3 commit msg
        * 2eb6fae commit msg
    * 1980-11-08 03:56  **1.1.0**  initial release
        * 2eb6fae commit msg

 * Version **1.0** - Minor Title
    * 1980-11-08 03:56  **1.0.0**  initial release
        * 2eb6fae commit msg

## VERSION 0  BETA

 * Version **0.9** - Minor Title
    * 1980-11-08 12:34  **0.9.1**  patch comment
       * ada96f3 commit msg
       * 2eb6fae commit msg
       * 2eb6fae commit msg
    * 1980-11-08 03:56  **0.9.0**  initial release
```

and rendered:
## VERSION 1  MAJOR TITLE

 * Version **1.1** - Minor Title
    * 1980-11-08 12:34  **1.1.1**  patch comment
        * ada96f3 commit msg
        * 2eb6fae commit msg
    * 1980-11-08 03:56  **1.1.0**  initial release
        * 2eb6fae commit msg

 * Version **1.0** - Minor Title
    * 1980-11-08 03:56  **1.0.0**  initial release
        * 2eb6fae commit msg

## VERSION 0  BETA

 * Version **0.9** - Minor Title
    * 1980-11-08 12:34  **0.9.1**  patch comment
       * ada96f3 commit msg
       * 2eb6fae commit msg
       * 2eb6fae commit msg
    * 1980-11-08 03:56  **0.9.0**  initial release