### PR TITLE
Fix the ordering of configuration keys for actions lists.

### DIFF
--- a/src/Liip/RMT/Command/BaseCommand.php
+++ b/src/Liip/RMT/Command/BaseCommand.php
@@ -101,7 +101,7 @@ abstract class BaseCommand extends Command
         foreach (array('version-generator', 'version-persister') as $service) {
             Context::getInstance()->setService($service, $config[$service]['class'], $config[$service]['options']);
         }
-        foreach (array('prerequisites', 'pre-release-actions', 'post-release-actions') as $listName) {
+        foreach (Handler::ACTIONS_LIST as $listName) {
             Context::getInstance()->createEmptyList($listName);
             foreach ($config[$listName] as $service) {
                 Context::getInstance()->addToList($listName, $service['class'], $service['options']);

--- a/src/Liip/RMT/Command/ReleaseCommand.php
+++ b/src/Liip/RMT/Command/ReleaseCommand.php
@@ -11,6 +11,7 @@
 
 namespace Liip\RMT\Command;
 
+use Liip\RMT\Config\Handler;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Liip\RMT\Information\InformationCollector;
@@ -63,7 +64,7 @@ class ReleaseCommand extends BaseCommand
         $ic->registerRequests(Context::get('version-persister')->getInformationRequests());
 
         // Register options of all lists (prerequistes and actions)
-        foreach (array('prerequisites', 'pre-release-actions', 'post-release-actions') as $listName) {
+        foreach (Handler::ACTIONS_LIST as $listName) {
             foreach (Context::getInstance()->getList($listName) as $listItem) {
                 $ic->registerRequests($listItem->getInformationRequests());
             }

--- a/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
+++ b/test/Liip/RMT/Tests/Unit/Config/HandlerTest.php
@@ -123,10 +123,41 @@ class HandlerTest extends \PHPUnit\Framework\TestCase
     public function testMerge()
     {
         $configHandler = new Handler(array(
+            'pre-release-actions' => [
+                'command' => [
+                    'class' => 'Liip\\RMT\\Action\\CommandAction',
+                    'options' => [
+                        'cmd' => 'echo "project_default_config";',
+                    ]
+                ],
+                'changelog-update' => [
+                    'class' => 'Liip\\RMT\\Action\\ChangelogUpdateAction',
+                    'options' => [
+                        'format' => 'semantic',
+                        'file' => 'CHANGELOG.md',
+                    ]
+                ],
+                'vcs-commit' => [
+                    'class' => 'Liip\\RMT\\Action\\VcsCommitAction',
+                    'options' => [],
+                ],
+            ],
             'version-persister' => 'foo',
             'version-generator' => 'bar',
             'branch-specific' => array(
                 'dev' => array(
+                    'pre-release-actions' => [
+                        'command' => [
+                            'class' => 'Liip\\RMT\\Action\\CommandAction',
+                            'options' => [
+                                'cmd' => 'echo "project_dev_config";',
+                            ]
+                        ],
+                        'vcs-commit' => [
+                            'class' => 'Liip\\RMT\\Action\\VcsCommitAction',
+                            'options' => [],
+                        ],
+                    ],
                     'version-generator' => 'foobar',
                 ),
             ),
@@ -135,21 +166,51 @@ class HandlerTest extends \PHPUnit\Framework\TestCase
         $method = new \ReflectionMethod('Liip\RMT\Config\Handler', 'mergeConfig');
         $method->setAccessible(true);
 
-        $this->assertEquals($method->invokeArgs($configHandler, array()), array(
+        // "assertSame" is needed here to compare the array's ordering too (assertEquals doesn't)
+        $this->assertSame($method->invokeArgs($configHandler, array()), array(
             'vcs' => null,
             'prerequisites' => array(),
-            'pre-release-actions' => array(),
-            'post-release-actions' => array(),
+            'pre-release-actions' => [
+                'command' => [
+                    'class' => 'Liip\\RMT\\Action\\CommandAction',
+                    'options' => [
+                        'cmd' => 'echo "project_default_config";',
+                    ]
+                ],
+                'changelog-update' => [
+                    'class' => 'Liip\\RMT\\Action\\ChangelogUpdateAction',
+                    'options' => [
+                        'format' => 'semantic',
+                        'file' => 'CHANGELOG.md',
+                    ]
+                ],
+                'vcs-commit' => [
+                    'class' => 'Liip\\RMT\\Action\\VcsCommitAction',
+                    'options' => [],
+                ],
+            ],
             'version-generator' => 'bar',
             'version-persister' => 'foo',
+            'post-release-actions' => array(),
         ));
-        $this->assertEquals($method->invokeArgs($configHandler, array('dev')), array(
+        $this->assertSame($method->invokeArgs($configHandler, array('dev')), array(
             'vcs' => null,
             'prerequisites' => array(),
-            'pre-release-actions' => array(),
-            'post-release-actions' => array(),
+            'pre-release-actions' => [
+                'command' => [
+                    'class' => 'Liip\\RMT\\Action\\CommandAction',
+                    'options' => [
+                        'cmd' => 'echo "project_dev_config";',
+                    ]
+                ],
+                'vcs-commit' => [
+                    'class' => 'Liip\\RMT\\Action\\VcsCommitAction',
+                    'options' => [],
+                ],
+            ],
             'version-generator' => 'foobar',
             'version-persister' => 'foo',
+            'post-release-actions' => array(),
         ));
     }
 


### PR DESCRIPTION
Somehow the order of the tasks is lost (which leaves the changelog modification uncommited) with the following configuration. It's caused by "array_replace_recursive" (introduced in https://github.com/liip/RMT/commit/872f3362a493dc2690d7daab122a71b3dd3fff6f), which doesn't maintain order of keys.

This PR fixes that (manually, there's unfortunately no native PHP function that does what we need - code can maybe be optimized, feel free to comment !) and adapts the tests to cover it.

```
# Output of "./RMT release"
 Pre-release-actions 

    1) Updating the assets version... : Version number [1.8.3] updated in app/config/application_version.yml: OK
    2) Vcs Commit Action : OK
    3) Changelog Update Action : OK
```

```
# .rmt.yml
_default:
    pre-release-actions:
        "bin/custom/UpdateApplicationVersion.php": ~
        vcs-commit: ~
master:
    pre-release-actions:
        "bin/custom/UpdateApplicationVersion.php": ~
        changelog-update:
            format: semantic
            file: CHANGELOG.md
        vcs-commit: ~
```