### PR TITLE
Allow multiple files to be updated by UpdateVersionClassAction

### DIFF
--- a/src/Liip/RMT/Action/UpdateVersionClassAction.php
+++ b/src/Liip/RMT/Action/UpdateVersionClassAction.php
@@ -39,19 +39,39 @@ class UpdateVersionClassAction extends BaseAction
 
     public function execute()
     {
-        if (!isset($this->options['class'])) {
+        if (isset($this->options['class'])) {
+            $filename = $this->getFilename($this->options['class']);
+            $this->updateFile($filename);
+            $this->confirmSuccess();
+        } else if (!empty($this->options)) {
+            foreach ($this->options as $key => $section) {
+                if (isset($this->options['class'])) {
+                    throw new ConfigException('You must specify the class or file to update');
+                }
+                $filename = $this->getFilename($section['class']);
+                $this->updateFile($filename);
+            }
+            $this->confirmSuccess();
+        } else {
             throw new ConfigException('You must specify the class or file to update');
         }
+    }
 
-        if (file_exists($this->options['class'])) {
-            $filename = $this->options['class'];
+    /**
+     * converts a class name to a file path, but keeps file paths as is
+     *
+     * @param string $class the class name or file path
+     * @return string the file path
+     * @throws \ReflectionException
+     */
+    protected function getFilename($class)
+    {
+        if (file_exists($class)) {
+            return $class;
         } else {
-            $versionClass = new \ReflectionClass($this->options['class']);
-            $filename = $versionClass->getFileName();
+            $versionClass = new \ReflectionClass($class);
+            return $versionClass->getFileName();
         }
-
-        $this->updateFile($filename);
-        $this->confirmSuccess();
     }
 
     /**

--- a/src/Liip/RMT/Action/UpdateVersionClassAction.php
+++ b/src/Liip/RMT/Action/UpdateVersionClassAction.php
@@ -39,22 +39,22 @@ class UpdateVersionClassAction extends BaseAction
 
     public function execute()
     {
+        $filelist = array();
         if (isset($this->options['class'])) {
-            $filename = $this->getFilename($this->options['class']);
-            $this->updateFile($filename);
-            $this->confirmSuccess();
+            $filelist[] = $this->getFilename($this->options['class']);
         } else if (!empty($this->options)) {
             foreach ($this->options as $key => $section) {
-                if (isset($this->options['class'])) {
+                if (!isset($section['class'])) {
                     throw new ConfigException('You must specify the class or file to update');
                 }
-                $filename = $this->getFilename($section['class']);
-                $this->updateFile($filename);
+                $filelist[] = $this->getFilename($section['class']);
             }
-            $this->confirmSuccess();
         } else {
             throw new ConfigException('You must specify the class or file to update');
         }
+
+        $this->updateFiles($filelist);
+        $this->confirmSuccess();
     }
 
     /**
@@ -71,6 +71,21 @@ class UpdateVersionClassAction extends BaseAction
         } else {
             $versionClass = new \ReflectionClass($class);
             return $versionClass->getFileName();
+        }
+    }
+
+    /**
+     * will update all given files with the current version
+     *
+     * @param array $filelist list of all files to update
+     *
+     * @throws \Liip\RMT\Exception
+     * @see #updateFile
+     */
+    protected function updateFiles($filelist)
+    {
+        foreach ($filelist as $key => $file) {
+            $this->updateFile($file);
         }
     }
 


### PR DESCRIPTION
This PR fixes the issue described in #67.

The new syntax would be like this:
```yaml
update-version-class:
  -
    class: first-file.php
  -
    class: second-file.config
```

It still recognizes and uses the old syntax.

It is also possible to use custom keys instead of a list, but the presence of a key named `class` will cause usage of the old syntax exclusively:
```yaml
update-version-class:
  important-php-file:
    class: first-file.php
  configuration:
    class: second-file.config
```
