### PR TITLE
Allow sensiolabs/security-checker in the version 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "~2.3|^3.0|^4.0",
         "symfony/process": "~2.3|^3.0|^4.0",
         "vierbergenlars/php-semver": "~3.0",
-        "sensiolabs/security-checker": "~2.0|^3.0|^4.0"
+        "sensiolabs/security-checker": "~2.0|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6.8|^6.0"


### PR DESCRIPTION
https://twitter.com/fabpot/status/1099994260051582978 - security-checker up to version 4 is not usable anymore