### PR TITLE
Use latest security-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "~2.3|^3.0|^4.0",
         "symfony/process": "~2.3|^3.0|^4.0",
         "vierbergenlars/php-semver": "~3.0",
-        "sensiolabs/security-checker": "~2.0|^3.0|^4.0"
+        "sensiolabs/security-checker": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6.8|^6.0"


### PR DESCRIPTION
All other version (<5.0) won't work, because they changed the host name from `security.sensiolabs.org` to `security.symfony.com`

Refs https://github.com/sensiolabs/security-checker/issues/149