### PR TITLE
Create prerequisite that checks composer dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ Prerequisite actions are executed before the interactive part.
 * `composer-stability-check`: will check if the composer.json is set to the right minimum-stability
   * Option `stability`: the stability that should be set in the minimum-stability field (default: *stable*)
 * `composer-security-check`: run the composer.lock against https://security.sensiolabs.org/ to check for known vulnerabilities in the dependencies
+* `composer-dependency-stability-check`: test if only allowed dependencies are using development versions
+    * Option `ignore-require` and `ignore-require-dev`: don't check dependencies in `require` or `require-dev` section
+    * Option `whitelist`: allow specific dependencies to use development version
 * `command`: Execute a system command
     * Option `cmd` The command to execute
     * Option `live_output` boolean, do we display the command output? (default: *true*)
@@ -255,6 +258,20 @@ Most of the time, it will be easier for you to pick up an example below and adap
     version-generator: simple
     version-persister: vcs-tag
     prerequisites: [working-copy-check, display-last-changes]
+    
+### Using Git tags, simple versioning and composer-prerequisites
+
+    vcs: git
+    version-generator: simple
+    version-persister: vcs-tag
+    prerequisites:
+        - composer-json-check
+        - composer-stability-check:
+            stability: beta
+        - composer-dependency-stability-check:
+            whitelist:
+                - [symfony/console]
+                - [phpunit/phpunit, require-dev]
     
 ### Using Git tags, simple versioning and prerequisites, and gpg sign commit and tags
 

--- a/src/Liip/RMT/Prerequisite/ComposerDependencyStabilityCheck.php
+++ b/src/Liip/RMT/Prerequisite/ComposerDependencyStabilityCheck.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the project RMT
+ *
+ * Copyright (c) 2014, Liip AG, http://www.liip.ch
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Liip\RMT\Prerequisite;
+
+use Liip\RMT\Action\BaseAction;
+use Liip\RMT\Context;
+use Liip\RMT\Information\InformationRequest;
+
+/**
+ * Test if only allowed dependencies use unstable versions.
+ */
+class ComposerDependencyStabilityCheck extends BaseAction
+{
+
+    const SKIP_OPTION = 'skip-composer-dependency-stability-check';
+    const DEPENDENCY_LISTS = array('require', 'require-dev');
+
+    private $whitelist;
+    private $dependencyListWhitelists;
+
+    public function __construct($options)
+    {
+        $this->options = array_merge(
+            array(
+                'ignore-require-dev' => false,
+                'ignore-require' => false,
+                'whitelist' => array(),
+            ),
+            $options
+        );
+
+        $this->whitelist = array();
+
+        foreach ($options['whitelist'] as $listing) {
+            if (!isset($listing[1])) {
+                $this->whitelist[] = $listing[0];
+            } else {
+                $elementSize = sizeof($listing);
+                for ($index = 1 ; $index < $elementSize ; ++$index) {
+                    $element = $listing[$index];
+                    if (!isset($this->dependencyListWhitelists[$element])) {
+                        $this->dependencyListWhitelists[$element] = array();
+                    }
+                    $this->dependencyListWhitelists[$element][] = $listing[0];
+                }
+            }
+        }
+    }
+
+    public function execute()
+    {
+        if (Context::get('information-collector')->getValueFor(self::SKIP_OPTION)) {
+            Context::get('output')->writeln('<error>composer dependency-stability check skipped</error>');
+            return;
+        }
+
+        if (!file_exists('composer.json')) {
+            Context::get('output')->writeln('<error>composer.json does not exist, skipping check</error>');
+            return;
+        }
+
+        if (!is_readable('composer.json')) {
+            throw new \Exception(
+                'composer.json can not be read (permissions?), (you can force a release with option --'
+                . self::SKIP_OPTION.')'
+            );
+        }
+
+        $contents = json_decode(file_get_contents('composer.json'), true);
+
+        foreach (self::DEPENDENCY_LISTS as $dependencyList) {
+            if (!$this->isListIgnored($dependencyList) && $this->listExists($contents, $dependencyList)) {
+                $specificWhitelist = $this->generateListSpecificWhitelist($dependencyList);
+                $this->checkDependencies($contents[$dependencyList], $specificWhitelist);
+            }
+        }
+
+        $this->confirmSuccess();
+    }
+
+    /**
+     * @param $dependencyList
+     * @return mixed
+     */
+    private function isListIgnored($dependencyList)
+    {
+        return isset($this->options['ignore-' . $dependencyList]) && $this->options['ignore-' . $dependencyList] === true;
+    }
+
+    /**
+     * @param $contents
+     * @param $dependencyList
+     * @return bool
+     */
+    private function listExists($contents, $dependencyList)
+    {
+        return isset($contents[$dependencyList]);
+    }
+
+    /**
+     * @param $dependencyList
+     * @return array
+     */
+    private function generateListSpecificWhitelist($dependencyList)
+    {
+        if (isset($this->dependencyListWhitelists[$dependencyList])) {
+            return array_merge($this->whitelist, $this->dependencyListWhitelists[$dependencyList]);
+        } else {
+            return $this->whitelist;
+        }
+    }
+
+    /**
+     * check every element inside this array for composer version strings and throw an exception if the dependency is
+     * not stable
+     *
+     * @param $dependencyList array
+     * @param $whitelist array
+     * @throws \Exception
+     */
+    private function checkDependencies($dependencyList, $whitelist = array()) {
+        foreach ($dependencyList as $dependency => $version) {
+            if (($this->startsWith($version, 'dev-') || $this->endsWith($version, '@dev'))
+                && !in_array($dependency, $whitelist)) {
+                throw new \Exception(
+                    $dependency
+                    . ' uses dev-version but is not listed on whitelist '
+                    . ' (you can force a release with option --'.self::SKIP_OPTION.')'
+                );
+            }
+        }
+    }
+
+    /**
+     * @param $haystack string
+     * @param $needle string
+     * @return bool
+     */
+    private function startsWith($haystack, $needle)
+    {
+        return $haystack[0] === $needle[0]
+            ? strncmp($haystack, $needle, strlen($needle)) === 0
+            : false;
+    }
+
+    /**
+     * @param $haystack string
+     * @param $needle string
+     * @return bool
+     */
+    private function endsWith($haystack, $needle) {
+        return $needle === '' || substr_compare($haystack, $needle, -strlen($needle)) === 0;
+    }
+
+    public function getInformationRequests()
+    {
+        return array(
+            new InformationRequest(
+                self::SKIP_OPTION,
+                array(
+                    'description' => 'Do not check composer.json for minimum-stability before the release',
+                    'type' => 'confirmation',
+                    'interactive' => false,
+                )
+            ),
+        );
+    }
+}

--- a/src/Liip/RMT/Prerequisite/ComposerDependencyStabilityCheck.php
+++ b/src/Liip/RMT/Prerequisite/ComposerDependencyStabilityCheck.php
@@ -29,29 +29,30 @@ class ComposerDependencyStabilityCheck extends BaseAction
 
     public function __construct($options)
     {
-        $this->options = array_merge(
-            array(
-                'ignore-require-dev' => false,
-                'ignore-require' => false,
-                'whitelist' => array(),
-            ),
-            $options
-        );
+        parent::__construct($options);
 
         $this->whitelist = array();
+        $this->dependencyListWhitelists = array();
 
-        foreach ($options['whitelist'] as $listing) {
-            if (!isset($listing[1])) {
-                $this->whitelist[] = $listing[0];
-            } else {
-                $elementSize = sizeof($listing);
-                for ($index = 1 ; $index < $elementSize ; ++$index) {
-                    $element = $listing[$index];
-                    if (!isset($this->dependencyListWhitelists[$element])) {
-                        $this->dependencyListWhitelists[$element] = array();
-                    }
-                    $this->dependencyListWhitelists[$element][] = $listing[0];
+        if (isset($this->options['whitelist'])) {
+            $this->createWhitelists($this->options['whitelist']);
+        }
+    }
+
+    private function createWhitelists($whitelistConfig)
+    {
+        foreach ($whitelistConfig as $listing) {
+            if (isset($listing[1])) {
+                if (!in_array($listing[1], self::DEPENDENCY_LISTS)) {
+                    throw new \Exception("configuration error: "
+                    . $listing[1] . " is no valid composer dependency section");
                 }
+                if (!isset($this->dependencyListWhitelists[$listing[1]])) {
+                    $this->dependencyListWhitelists[$listing[1]] = array();
+                }
+                $this->dependencyListWhitelists[$listing[1]][] = $listing[0];
+            } else {
+                $this->whitelist[] = $listing[0];
             }
         }
     }


### PR DESCRIPTION
## Functionallity

This prerequisite tests if only allowed dependencies are using development versions and fails otherwise.

This check can be configured to:
* ignore either or both of `require` and `require-dev` dependencies
* ignore specific dependencies in either or both of `require` and `require-dev`

## Reason

The ComposerStabilityCheck does provide basic protection against accidental development version usage, but development versions can still be used with `minimum-stability` set to `stable` as composer allows overriding this setting per dependency.