### PR TITLE
Fix tests with php 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cache.properties
 /builds
 bin
 !bin/UpdateApplicationVersionCurrentVersion.php
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache
@@ -9,8 +7,10 @@ cache:
 
 matrix:
   include:
-    - php: nightly
+    - php: 8.0
       env: SYMFONY_VERSION=5.0.*
+    - php: 8.0
+      env: SYMFONY_VERSION=4.4.*
     - php: 7.4
       env: SYMFONY_VERSION=5.0.*
     - php: 7.4
@@ -31,7 +31,7 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
 
 before_install:
-  - sh -c 'if [ "${TRAVIS_PHP_VERSION}" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;'
+  - sh -c 'echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini'
   - git config --global user.email "test@test.com"
   - git config --global user.name "John Doe"
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,12 @@
         "issues": "http://github.com/liip/RMT/issues"
     },
     "require": {
-        "php": "^5.6 || ^7.0 || ^8.0",
-        "symfony/console": "~2.3|^3.0|^4.2|^5.0",
-        "symfony/yaml": "~2.3|^3.0|^4.2|^5.0",
-        "symfony/process": "~2.3|^3.0|^4.2|^5.0",
+        "php": "^7.1|^8.0",
+        "symfony/console": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0",
+        "symfony/process": "^3.4|^4.0|^5.0",
         "vierbergenlars/php-semver": "~3.0",
         "sensiolabs/security-checker": "^6.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^5.6.8|^6.0|^9.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0499c10f1c6377690fda5e75fa2379a5",
+    "content-hash": "e72bbdb96904041303af47d4eca364e4",
     "packages": [
         {
             "name": "psr/container",
@@ -53,20 +53,24 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +104,10 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -148,30 +155,37 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
+            "support": {
+                "issues": "https://github.com/sensiolabs/security-checker/issues",
+                "source": "https://github.com/sensiolabs/security-checker/tree/master"
+            },
             "time": "2019-11-01T13:20:14+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.0.0",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "1ece22ce0c2d54572dafcd114cc08c0031cc0ac3"
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1ece22ce0c2d54572dafcd114cc08c0031cc0ac3",
-                "reference": "1ece22ce0c2d54572dafcd114cc08c0031cc0ac3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e0564fb08d44a98bd5f1960204c958e57bd586b",
+                "reference": "3e0564fb08d44a98bd5f1960204c958e57bd586b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
+                "php": ">=7.2.5",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/service-contracts": "^1.1|^2"
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
                 "symfony/lock": "<4.4",
                 "symfony/process": "<4.4"
@@ -195,11 +209,6 @@
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -224,30 +233,119 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-18T17:27:11+00:00"
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-28T11:24:18+00:00"
         },
         {
-            "name": "symfony/http-client",
-            "version": "v5.0.0",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/http-client.git",
-                "reference": "e68e5680f2bfda0b17097fde6d28b61d87c757ee"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/e68e5680f2bfda0b17097fde6d28b61d87c757ee",
-                "reference": "e68e5680f2bfda0b17097fde6d28b61d87c757ee",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
-                "psr/log": "^1.0",
-                "symfony/http-client-contracts": "^1.1.8|^2",
-                "symfony/polyfill-php73": "^1.11"
+                "php": ">=7.1"
             },
-            "conflict": {
-                "symfony/http-kernel": "<4.4"
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "5b9fc5d85a6cec73832ff170ccd468d97dd082d9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/5b9fc5d85a6cec73832ff170ccd468d97dd082d9",
+                "reference": "5b9fc5d85a6cec73832ff170ccd468d97dd082d9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/log": "^1.0",
+                "symfony/http-client-contracts": "^2.2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.0|^2"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -256,22 +354,20 @@
                 "symfony/http-client-implementation": "1.1"
             },
             "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
                 "guzzlehttp/promises": "^1.3.1",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4.13|^5.1.5",
                 "symfony/process": "^4.4|^5.0",
-                "symfony/service-contracts": "^1.0|^2",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpClient\\": ""
@@ -296,32 +392,54 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-21T07:02:40+00:00"
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-28T13:45:20+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v2.0.0",
+            "version": "v2.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "f1aa62591e44a737d4589a0913ac49b84313c19d"
+                "reference": "41db680a15018f9c1d4b23516059633ce280ca33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/f1aa62591e44a737d4589a0913ac49b84313c19d",
-                "reference": "f1aa62591e44a737d4589a0913ac49b84313c19d",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41db680a15018f9c1d4b23516059633ce280ca33",
+                "reference": "41db680a15018f9c1d4b23516059633ce280ca33",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.9"
+                "php": ">=7.2.5"
             },
             "suggest": {
                 "symfony/http-client-implementation": ""
             },
             "type": "library",
             "extra": {
+                "branch-version": "2.3",
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "2.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -353,40 +471,58 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-11-09T09:18:34+00:00"
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-14T17:08:19+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v5.0.0",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "76f3c09b7382bf979af7bcd8e6f8033f1324285e"
+                "reference": "05f667e8fa029568964fd3bec6bc17765b853cc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/76f3c09b7382bf979af7bcd8e6f8033f1324285e",
-                "reference": "76f3c09b7382bf979af7bcd8e6f8033f1324285e",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/05f667e8fa029568964fd3bec6bc17765b853cc5",
+                "reference": "05f667e8fa029568964fd3bec6bc17765b853cc5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0"
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
                 "symfony/mailer": "<4.4"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10",
-                "symfony/dependency-injection": "^4.4|^5.0"
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/property-access": "^4.4|^5.1",
+                "symfony/property-info": "^4.4|^5.1",
+                "symfony/serializer": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Mime\\": ""
@@ -415,24 +551,41 @@
                 "mime",
                 "mime-type"
             ],
-            "time": "2019-11-18T17:27:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-30T14:55:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -440,7 +593,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -473,26 +630,41 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-idn",
-            "version": "v1.12.0",
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2"
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
-                "reference": "6af626ae6fa37d396dc90a399c0ff08e5cfc45b2",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php72": "^1.9"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -500,7 +672,94 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/3b75acd829741c768bc8b1f84eb33265e7cc5117",
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -521,6 +780,10 @@
                     "email": "laurent@bassin.info"
                 },
                 {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
@@ -535,24 +798,125 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.12.0",
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "727d1096295d807c309fb01a851577302394c897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
+                "reference": "727d1096295d807c309fb01a851577302394c897",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -560,7 +924,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -594,29 +962,50 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.12.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e"
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cede45fcdfabdd6043b3592e83678e42ec69e930",
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -649,29 +1038,50 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.12.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -707,31 +1117,127 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v5.0.0",
+            "name": "symfony/polyfill-php80",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "110f98bed214a007eb440c7bb14088fed96f847f"
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/110f98bed214a007eb440c7bb14088fed96f847f",
-                "reference": "110f98bed214a007eb440c7bb14088fed96f847f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "240e74140d4d956265048f3025c0aecbbc302d54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/240e74140d4d956265048f3025c0aecbbc302d54",
+                "reference": "240e74140d4d956265048f3025c0aecbbc302d54",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "type": "library",
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -756,24 +1262,41 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-18T17:27:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-02T15:47:15+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.0.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "9d99e1556417bf227a62e14856d630672bf10eaf"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/9d99e1556417bf227a62e14856d630672bf10eaf",
-                "reference": "9d99e1556417bf227a62e14856d630672bf10eaf",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.9",
+                "php": ">=7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -782,7 +1305,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -814,24 +1341,125 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-11-09T09:18:34+00:00"
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v5.0.0",
+            "name": "symfony/string",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "51b684480184fa767b97e28eaca67664e48dd3e9"
+                "url": "https://github.com/symfony/string.git",
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/51b684480184fa767b97e28eaca67664e48dd3e9",
-                "reference": "51b684480184fa767b97e28eaca67664e48dd3e9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/40e975edadd4e32cd16f3753b3bad65d9ac48242",
+                "reference": "40e975edadd4e32cd16f3753b3bad65d9ac48242",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5",
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony String component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T12:08:07+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "bb73619b2ae5121bbbcd9f191dfd53ded17ae598"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/bb73619b2ae5121bbbcd9f191dfd53ded17ae598",
+                "reference": "bb73619b2ae5121bbbcd9f191dfd53ded17ae598",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
@@ -843,12 +1471,10 @@
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
             },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
@@ -873,7 +1499,24 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-18T17:27:11+00:00"
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-28T10:57:20+00:00"
         },
         {
             "name": "vierbergenlars/php-semver",
@@ -925,1477 +1568,22 @@
                 "semver",
                 "versioning"
             ],
+            "support": {
+                "issues": "https://github.com/vierbergenlars/php-semver/issues",
+                "source": "https://github.com/vierbergenlars/php-semver/tree/master"
+            },
             "time": "2017-07-11T09:53:59+00:00"
         }
     ],
-    "packages-dev": [
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2019-10-21T16:45:58+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.9.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "time": "2019-08-09T12:45:53+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2018-08-07T13:53:10+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
-                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "^1.0.5",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "^7.1",
-                "mockery/mockery": "~1",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "time": "2019-08-22T18:11:29+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "1.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2019-10-03T11:07:50+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-xdebug": "^2.5.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2018-04-06T15:36:58+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "time": "2017-11-27T13:52:08+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2015-06-21T13:50:34+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "1.0.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-11-27T05:48:46+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "6.5.14",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
-            },
-            "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.5.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2019-02-01T05:22:47+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "2.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
-                "sebastian/exporter": "^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "time": "2018-02-01T13:46:46+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2017-08-03T08:09:46+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "time": "2017-07-01T08:51:00+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
-            },
-            "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "time": "2019-09-14T09:02:43+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "time": "2017-04-27T15:39:26+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
-                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "vimeo/psalm": "<3.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2019-11-24T13:36:37+00:00"
-        }
-    ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6|^7.0"
+        "php": "^7.1|^8.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }

--- a/test/Liip/RMT/Tests/Functional/BuildPharPackageActionTest.php
+++ b/test/Liip/RMT/Tests/Functional/BuildPharPackageActionTest.php
@@ -15,13 +15,13 @@ use Phar;
 
 class BuildPharPackageActionTest extends RMTFunctionalTestBase
 {
-    const START_VERSION = '1.0.0';
+    public const START_VERSION = '1.0.0';
 
-    const GENERATED_PACKAGE_PATH = '/tmp/configured/my-new-package-1.0.1.phar';
+    public const GENERATED_PACKAGE_PATH = '/tmp/configured/my-new-package-1.0.1.phar';
 
-    const STUB_FILE = 'stub-file.php';
+    public const STUB_FILE = 'stub-file.php';
 
-    const STUB_FILE_WEB = 'stub-file-web.php';
+    public const STUB_FILE_WEB = 'stub-file-web.php';
 
     protected function setUp(): void
     {
@@ -50,21 +50,21 @@ class BuildPharPackageActionTest extends RMTFunctionalTestBase
         exec('git tag ' . self::START_VERSION);
     }
 
-    public function testPackageNameContainsPackageNameOptionAndVersion()
+    public function testPackageNameContainsPackageNameOptionAndVersion(): void
     {
         exec('./RMT release -n', $consoleOutput, $exitCode);
 
-        $this->assertContains('my-new-package-1.0.1.phar', implode("\n", $consoleOutput));
+        self::assertStringContainsString('my-new-package-1.0.1.phar', implode("\n", $consoleOutput));
     }
 
-    public function testPackageIsCreatedInTheConfiguredDirectory()
+    public function testPackageIsCreatedInTheConfiguredDirectory(): void
     {
         exec('./RMT release -n', $consoleOutput, $exitCode);
 
-        $this->assertContains(self::GENERATED_PACKAGE_PATH, implode("\n", $consoleOutput));
+        self::assertStringContainsString(self::GENERATED_PACKAGE_PATH, implode("\n", $consoleOutput));
     }
 
-    public function testPackageDoesNotContainsExcludedPaths()
+    public function testPackageDoesNotContainsExcludedPaths(): void
     {
         exec('touch excluded-file');
 
@@ -78,20 +78,19 @@ class BuildPharPackageActionTest extends RMTFunctionalTestBase
 
         $output = implode("\n", $consoleOutput);
 
-        $this->assertNotContains('excluded-file', $output);
-        $this->assertNotContains('.git', $output);
+        self::assertStringNotContainsString('excluded-file', $output);
+        self::assertStringNotContainsString('.git', $output);
     }
 
-    public function testPackageHasConfiguredMetadata()
+    public function testPackageHasConfiguredMetadata(): void
     {
         exec('./RMT release -n');
 
         $phar = new Phar(self::GENERATED_PACKAGE_PATH);
-
-        $this->assertEquals($phar->getMetadata(), array('version' => '1.0.1', 'owner' => 'Paddington'));
+        self::assertEquals(['version' => '1.0.1', 'owner' => 'Paddington'], $phar->getMetadata());
     }
 
-    public function testPackageHasConfiguredStub()
+    public function testPackageHasConfiguredStub(): void
     {
         exec('touch ' . self::STUB_FILE);
         exec('touch ' . self::STUB_FILE_WEB);
@@ -100,11 +99,11 @@ class BuildPharPackageActionTest extends RMTFunctionalTestBase
 
         $phar = new Phar(self::GENERATED_PACKAGE_PATH);
 
-        $this->assertContains(self::STUB_FILE, $phar->getStub());
-        $this->assertContains(self::STUB_FILE_WEB, $phar->getStub());
+        self::assertStringContainsString(self::STUB_FILE, $phar->getStub());
+        self::assertStringContainsString(self::STUB_FILE_WEB, $phar->getStub());
     }
 
-    protected function extractPackage($source, $target)
+    protected function extractPackage($source, $target): void
     {
         $phar = new Phar($source);
         $phar->extractTo($target);

--- a/test/Liip/RMT/Tests/Functional/ChangelogDumpCommitsTest.php
+++ b/test/Liip/RMT/Tests/Functional/ChangelogDumpCommitsTest.php
@@ -13,7 +13,7 @@ namespace Liip\RMT\Tests\Functional;
 
 class ChangelogDumpCommitsTest extends RMTFunctionalTestBase
 {
-    public function testDump()
+    public function testDump(): void
     {
         $this->createConfig('semantic', 'vcs-tag', array(
             'vcs' => 'git',
@@ -30,14 +30,14 @@ class ChangelogDumpCommitsTest extends RMTFunctionalTestBase
         // First release must contain as message explaining why there is no commit dump
         exec('./RMT release -n --confirm-first --comment="First release"', $output);
         $output = implode("\n", $output);
-        $this->assertContains('No commits dumped as this is the first release', $output);
+        self::assertStringContainsString('No commits dumped as this is the first release', $output);
 
         // Next release must update the CHANGELOG
         exec('echo "text" > new-file && git add -A && git commit -m "Second commit"');
         exec('echo "text2" >> new-file && git commit -am "Third commit"');
         exec('./RMT release -n --comment="Second release"', $output);
         $changelog = file_get_contents($this->tempDir . '/CHANGELOG');
-        $this->assertContains('Second commit', $changelog);
-        $this->assertContains('Third commit', $changelog);
+        self::assertStringContainsString('Second commit', $changelog);
+        self::assertStringContainsString('Third commit', $changelog);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/ChangelogTest.php
+++ b/test/Liip/RMT/Tests/Functional/ChangelogTest.php
@@ -13,7 +13,7 @@ namespace Liip\RMT\Tests\Functional;
 
 class ChangelogTest extends RMTFunctionalTestBase
 {
-    public function testSimple()
+    public function testSimple(): void
     {
         $this->createChangelog('simple');
         $this->createConfig('simple', 'changelog');
@@ -21,7 +21,7 @@ class ChangelogTest extends RMTFunctionalTestBase
         $this->executeTest(null, 'comment2', '2');
     }
 
-    public function testSemantic()
+    public function testSemantic(): void
     {
         $this->createChangelog('semantic');
         $this->createConfig('semantic', 'changelog');
@@ -39,7 +39,7 @@ class ChangelogTest extends RMTFunctionalTestBase
      * @param String comment
      * @param String expected version number (ie 2.0.0)
      */
-    protected function executeTest($semanticType, $comment, $expectedVersion)
+    protected function executeTest($semanticType, $comment, $expectedVersion): void
     {
         //        $this->manualDebug();
         if (is_null($semanticType)) {
@@ -48,7 +48,7 @@ class ChangelogTest extends RMTFunctionalTestBase
             exec('./RMT release -n --type='.$semanticType . ' --comment="' . $comment . '"');
         }
         $changelog = file_get_contents($this->tempDir . '/CHANGELOG');
-        $this->assertRegExp('/' . $expectedVersion . '/', $changelog);
-        $this->assertRegExp('/' . $comment . '/', $changelog);
+        self::assertMatchesRegularExpression('/' . $expectedVersion . '/', $changelog);
+        self::assertMatchesRegularExpression('/' . $comment . '/', $changelog);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/CommandActionTest.php
+++ b/test/Liip/RMT/Tests/Functional/CommandActionTest.php
@@ -13,7 +13,7 @@ namespace Liip\RMT\Tests\Functional;
 
 class CommandActionTest extends RMTFunctionalTestBase
 {
-    public function testCommand()
+    public function testCommand(): void
     {
         $this->createChangelog('simple');
         $this->createConfig('simple', 'changelog', array(
@@ -24,6 +24,6 @@ class CommandActionTest extends RMTFunctionalTestBase
         exec('./RMT release -n --no-ansi --comment="test"', $output);
         $output = implode("\n", $output);
 //        $this->manualDebug();
-        $this->assertContains('Command Action : echo "hello world"', $output);
+        self::assertStringContainsString('Command Action : echo "hello world"', $output);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/CurrentCommandTest.php
+++ b/test/Liip/RMT/Tests/Functional/CurrentCommandTest.php
@@ -13,38 +13,38 @@ namespace Liip\RMT\Tests\Functional;
 
 class CurrentCommandTest extends RMTFunctionalTestBase
 {
-    public function testNormal()
+    public function testNormal(): void
     {
         $this->initGit();
         $this->createConfig('simple', 'vcs-tag', array('vcs' => 'git'));
         exec('git tag 4');
-        $this->assertEquals('Current release is: 4', exec('./RMT current --no-ansi'));
+        self::assertEquals('Current release is: 4', exec('./RMT current --no-ansi'));
     }
 
-    public function testRaw()
+    public function testRaw(): void
     {
         $this->initGit();
         $this->createConfig('semantic', 'vcs-tag', array('vcs' => 'git'));
         exec('git tag 2.3.4');
-        $this->assertEquals('2.3.4', exec('./RMT current --raw'));
+        self::assertEquals('2.3.4', exec('./RMT current --raw'));
     }
 
-    public function testVCSTag()
+    public function testVCSTag(): void
     {
         $this->initGit();
         $this->createConfig('semantic', array('name' => 'vcs-tag', 'tag-prefix' => 'toto_'), array('vcs' => 'git'));
         exec('git tag toto_2.3.4');
-        $this->assertEquals('2.3.4', exec('./RMT current --raw'));
-        $this->assertEquals('toto_2.3.4', exec('./RMT current --raw --vcs-tag'));
+        self::assertEquals('2.3.4', exec('./RMT current --raw'));
+        self::assertEquals('toto_2.3.4', exec('./RMT current --raw --vcs-tag'));
     }
 
-    public function testNumericCompare()
+    public function testNumericCompare(): void
     {
         $this->initGit();
         $this->createConfig('semantic', 'vcs-tag', array('vcs' => 'git'));
         exec('git tag 1.3.11');
         exec('git tag 1.3.10');
         exec('git tag 1.3.1');
-        $this->assertEquals('1.3.11', exec('./RMT current --raw'));
+        self::assertEquals('1.3.11', exec('./RMT current --raw'));
     }
 }

--- a/test/Liip/RMT/Tests/Functional/ExternalTasksTest.php
+++ b/test/Liip/RMT/Tests/Functional/ExternalTasksTest.php
@@ -13,18 +13,18 @@ namespace Liip\RMT\Tests\Functional;
 
 class ExternalTasksTest extends RMTFunctionalTestBase
 {
-    public function testInvalidScript()
+    public function testInvalidScript(): void
     {
         $scriptName = 'invalid-script-name.php';
         $this->createConfig('simple', 'git', array('pre-release-actions' => array($scriptName)));
         exec('./RMT release -n', $output);
         $output = implode("\n", $output);
 //        $this->manualDebug();
-        $this->assertContains('Impossible to open', $output);
-        $this->assertContains($scriptName, $output);
+        self::assertStringContainsString('Impossible to open', $output);
+        self::assertStringContainsString($scriptName, $output);
     }
 
-    public function testExternalTouch()
+    public function testExternalTouch(): void
     {
         $this->initGit();
         file_put_contents('touch-file1.php', '<?php touch("file1");');
@@ -33,6 +33,6 @@ class ExternalTasksTest extends RMTFunctionalTestBase
         ));
         exec('./RMT release -n');
         exec('ls', $files);
-        $this->assertTrue(in_array('file1', $files), 'file1 in present in [' . implode(', ', $files) . ']');
+        self::assertContains('file1', $files, 'file1 in present in ['.implode(', ', $files).']');
     }
 }

--- a/test/Liip/RMT/Tests/Functional/FilesUpdateTest.php
+++ b/test/Liip/RMT/Tests/Functional/FilesUpdateTest.php
@@ -13,7 +13,7 @@ namespace Liip\RMT\Tests\Functional;
 
 class FilesUpdateTest extends RMTFunctionalTestBase
 {
-    public function testTwoUpdate()
+    public function testTwoUpdate(): void
     {
         $ymlBefore = <<<YML
 my-project:
@@ -41,8 +41,8 @@ INI;
         file_put_contents('config.yml', $ymlBefore);
         file_put_contents('app.ini', $iniBefore);
         exec('./RMT release -n', $output);
-        $this->assertEquals($ymlAfter, file_get_contents('config.yml'));
-        $this->assertEquals($iniAfter, file_get_contents('app.ini'));
+        self::assertEquals($ymlAfter, file_get_contents('config.yml'));
+        self::assertEquals($iniAfter, file_get_contents('app.ini'));
     }
 
 }

--- a/test/Liip/RMT/Tests/Functional/ForwardCompatibilityTestCase.php
+++ b/test/Liip/RMT/Tests/Functional/ForwardCompatibilityTestCase.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Liip\RMT\Tests\Functional;
+
+use PHPUnit\Framework\TestCase;
+
+abstract class ForwardCompatibilityTestCase extends TestCase
+{
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertMatchesRegularExpression')) {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            parent::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertFileDoesNotExist')) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            parent::assertFileNotExists($filename, $message);
+        }
+    }
+}

--- a/test/Liip/RMT/Tests/Functional/GitTest.php
+++ b/test/Liip/RMT/Tests/Functional/GitTest.php
@@ -13,27 +13,27 @@ namespace Liip\RMT\Tests\Functional;
 
 class GitTest extends RMTFunctionalTestBase
 {
-    public function testInitialVersion()
+    public function testInitialVersion(): void
     {
         $this->initGit();
         $this->createConfig('simple', 'vcs-tag', array('vcs' => 'git'));
         exec('./RMT release -n --confirm-first');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('1'), $tags);
+        self::assertEquals(array('1'), $tags);
     }
 
-    public function testInitialVersionSemantic()
+    public function testInitialVersionSemantic(): void
     {
         $this->initGit();
         $this->createConfig('semantic', 'vcs-tag', array('vcs' => 'git'));
         exec('./RMT release -n  --type=patch --confirm-first');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('0.0.1'), $tags);
+        self::assertEquals(array('0.0.1'), $tags);
     }
 
-    public function testSimple()
+    public function testSimple(): void
     {
         $this->initGit();
         exec('git tag 1');
@@ -43,10 +43,10 @@ class GitTest extends RMTFunctionalTestBase
         exec('./RMT release -n');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('1', '3', '4', 'toto'), $tags);
+        self::assertEquals(array('1', '3', '4', 'toto'), $tags);
     }
 
-    public function testSemantic()
+    public function testSemantic(): void
     {
         $this->initGit();
         exec('git tag 2.1.19');
@@ -54,10 +54,10 @@ class GitTest extends RMTFunctionalTestBase
         exec('./RMT release -n --type=minor');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('2.1.19', '2.2.0'), $tags);
+        self::assertEquals(array('2.1.19', '2.2.0'), $tags);
     }
 
-    public function testTagPrefix()
+    public function testTagPrefix(): void
     {
         $this->initGit();
         exec('git tag 2');
@@ -66,16 +66,16 @@ class GitTest extends RMTFunctionalTestBase
         exec('./RMT release -n');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('2', 'v_1', 'v_2'), $tags);
+        self::assertEquals(array('2', 'v_1', 'v_2'), $tags);
     }
 
-    public function testTagPrefixWithBranchNamePlaceHolder()
+    public function testTagPrefixWithBranchNamePlaceHolder(): void
     {
         $this->initGit();
         $this->createConfig('simple', array('name' => 'vcs-tag', 'tag-prefix' => '_{branch-name}_'), array('vcs' => 'git'));
         exec('./RMT release -n --confirm-first');
         exec('git tag', $tags);
 //        $this->manualDebug();
-        $this->assertEquals(array('_master_1'), $tags);
+        self::assertEquals(array('_master_1'), $tags);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/HgTest.php
+++ b/test/Liip/RMT/Tests/Functional/HgTest.php
@@ -15,32 +15,32 @@ class HgTest extends RMTFunctionalTestBase
 {
     public static function cleanTags($tags)
     {
-        return array_map(function ($t) {
+        return array_map(static function ($t) {
             $parts = explode(' ', $t);
 
             return $parts[0];
         }, $tags);
     }
 
-    public function testInitialVersion()
+    public function testInitialVersion(): void
     {
         $this->initHg();
         $this->createConfig('simple', array('name' => 'vcs-tag', 'tag-prefix' => 'v'), array('vcs' => 'hg'));
         exec('./RMT release -n --confirm-first');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', 'v1'), static::cleanTags($tags));
+        self::assertEquals(array('tip', 'v1'), static::cleanTags($tags));
     }
 
-    public function testInitialVersionSemantic()
+    public function testInitialVersionSemantic(): void
     {
         $this->initHg();
         $this->createConfig('semantic', 'vcs-tag', array('vcs' => 'hg'));
         exec('./RMT release -n  --type=patch --confirm-first');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', '0.0.1'), static::cleanTags($tags));
+        self::assertEquals(array('tip', '0.0.1'), static::cleanTags($tags));
     }
 
-    public function testSimple()
+    public function testSimple(): void
     {
         $this->initHg();
         exec('hg tag v1');
@@ -49,20 +49,20 @@ class HgTest extends RMTFunctionalTestBase
         $this->createConfig('simple', array('name' => 'vcs-tag', 'tag-prefix' => 'v'), array('vcs' => 'hg'));
         exec('./RMT release -n');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', 'v4', 'toto', 'v3', 'v1'), static::cleanTags($tags));
+        self::assertEquals(array('tip', 'v4', 'toto', 'v3', 'v1'), static::cleanTags($tags));
     }
 
-    public function testSemantic()
+    public function testSemantic(): void
     {
         $this->initHg();
         exec('hg tag 2.1.19');
         $this->createConfig('semantic', 'vcs-tag', array('vcs' => 'hg'));
         exec('./RMT release -n --type=minor');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', '2.2.0', '2.1.19'), static::cleanTags($tags));
+        self::assertEquals(array('tip', '2.2.0', '2.1.19'), static::cleanTags($tags));
     }
 
-    public function testTagPrefix()
+    public function testTagPrefix(): void
     {
         $this->initHg();
         exec('hg tag v2');
@@ -70,19 +70,19 @@ class HgTest extends RMTFunctionalTestBase
         $this->createConfig('simple', array('name' => 'vcs-tag', 'tag-prefix' => 'v_'), array('vcs' => 'hg'));
         exec('./RMT release -n');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', 'v_2', 'v_1', 'v2'), static::cleanTags($tags));
+        self::assertEquals(array('tip', 'v_2', 'v_1', 'v2'), static::cleanTags($tags));
     }
 
-    public function testTagPrefixWithBranchNamePlaceHolder()
+    public function testTagPrefixWithBranchNamePlaceHolder(): void
     {
         $this->initHg();
         $this->createConfig('simple', array('name' => 'vcs-tag', 'tag-prefix' => '_{branch-name}_'), array('vcs' => 'hg'));
         exec('./RMT release -n --confirm-first');
         exec('hg tags', $tags);
-        $this->assertEquals(array('tip', '_default_1'), static::cleanTags($tags));
+        self::assertEquals(array('tip', '_default_1'), static::cleanTags($tags));
     }
 
-    protected function initHg()
+    protected function initHg(): void
     {
         exec('hg init');
         exec('echo "[ui]" > .hg/hgrc');

--- a/test/Liip/RMT/Tests/Functional/InitCommandTest.php
+++ b/test/Liip/RMT/Tests/Functional/InitCommandTest.php
@@ -15,27 +15,27 @@ use Symfony\Component\Yaml\Yaml;
 
 class InitCommandTest extends RMTFunctionalTestBase
 {
-    public function testInitConfig()
+    public function testInitConfig(): void
     {
         $configFile = '.rmt.yml';
         unlink($configFile);
-        $this->assertFileNotExists($configFile);
+        self::assertFileDoesNotExist($configFile);
         exec('./RMT init --configonly=n --vcs=git --generator=semantic-versioning --persister=vcs-tag -n');
 
 //        $this->manualDebug();
 
-        $this->assertFileExists($configFile);
+        self::assertFileExists($configFile);
         $config = Yaml::parse(file_get_contents($configFile), true);
 
         $defaultConfig = $config['_default'];
         $masterConfig = $config['master'];
 
-        $this->assertEquals('git', $defaultConfig['vcs']);
+        self::assertEquals('git', $defaultConfig['vcs']);
 
-        $this->assertEquals('simple', $defaultConfig['version-generator']);
-        $this->assertEquals('semantic', $masterConfig['version-generator']);
+        self::assertEquals('simple', $defaultConfig['version-generator']);
+        self::assertEquals('semantic', $masterConfig['version-generator']);
 
-        $this->assertEquals(array('vcs-tag' => array('tag-prefix' => '{branch-name}_')), $defaultConfig['version-persister']);
-        $this->assertEquals(array('vcs-tag' => array('tag-prefix' => '')), $masterConfig['version-persister']);
+        self::assertEquals(array('vcs-tag' => array('tag-prefix' => '{branch-name}_')), $defaultConfig['version-persister']);
+        self::assertEquals(array('vcs-tag' => array('tag-prefix' => '')), $masterConfig['version-persister']);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/PrerequisitesTest.php
+++ b/test/Liip/RMT/Tests/Functional/PrerequisitesTest.php
@@ -13,7 +13,7 @@ namespace Liip\RMT\Tests\Functional;
 
 class PrerequisitesTest extends RMTFunctionalTestBase
 {
-    public function testDisplayLastChange()
+    public function testDisplayLastChange(): void
     {
         $this->createConfig('simple', 'vcs-tag', array(
             'prerequisites' => array('display-last-changes'),
@@ -29,12 +29,12 @@ class PrerequisitesTest extends RMTFunctionalTestBase
 
         exec('./RMT release -n', $consoleOutput, $exitCode);
         $consoleOutput = implode("\n", $consoleOutput);
-        $this->assertNotContains('First commit', $consoleOutput);
-        $this->assertContains('Add a simple file', $consoleOutput);
-        $this->assertContains('Rename foo to bar', $consoleOutput);
+        self::assertStringNotContainsString('First commit', $consoleOutput);
+        self::assertStringContainsString('Add a simple file', $consoleOutput);
+        self::assertStringContainsString('Rename foo to bar', $consoleOutput);
     }
 
-    public function testWorkingCopyCheckFailsWithLocalModifications()
+    public function testWorkingCopyCheckFailsWithLocalModifications(): void
     {
         $this->createConfig('simple', 'vcs-tag', array(
             'prerequisites' => array('working-copy-check'),
@@ -46,11 +46,11 @@ class PrerequisitesTest extends RMTFunctionalTestBase
         // Release blocked by the check
         exec('touch toto');
         exec('./RMT release -n 2>&1', $consoleOutput, $exitCode);
-        $this->assertGreaterThan(0, $exitCode);
-        $this->assertContains('local modification', implode("\n", $consoleOutput));
+        self::assertGreaterThan(0, $exitCode);
+        self::assertStringContainsString('local modification', implode("\n", $consoleOutput));
     }
 
-    public function testWorkingCopyWithIgnoreCheck()
+    public function testWorkingCopyWithIgnoreCheck(): void
     {
         $this->createConfig('simple', 'vcs-tag', array(
             'prerequisites' => array('working-copy-check'=>array('allow-ignore'=>true)),
@@ -61,12 +61,12 @@ class PrerequisitesTest extends RMTFunctionalTestBase
 
         // Release working, check is ignore
         exec('./RMT release -n --ignore-check', $consoleOutput, $exitCode);
-        $this->assertEquals(0, $exitCode);
+        self::assertEquals(0, $exitCode);
         exec('git tag', $tags);
-        $this->assertEquals(array('1', '2'), $tags);
+        self::assertEquals(array('1', '2'), $tags);
     }
 
-    public function testWorkingCopy()
+    public function testWorkingCopy(): void
     {
         $this->createConfig('simple', 'vcs-tag', array(
             'prerequisites' => array('working-copy-check'),
@@ -79,8 +79,8 @@ class PrerequisitesTest extends RMTFunctionalTestBase
 
         // Normal case, check is passing
         exec('./RMT release -n', $consoleOutput, $exitCode);
-        $this->assertEquals(0, $exitCode, implode(PHP_EOL, $consoleOutput));
+        self::assertEquals(0, $exitCode, implode(PHP_EOL, $consoleOutput));
         exec('git tag', $tags2);
-        $this->assertEquals(array('1', '2'), $tags2);
+        self::assertEquals(array('1', '2'), $tags2);
     }
 }

--- a/test/Liip/RMT/Tests/Functional/RMTFunctionalTestBase.php
+++ b/test/Liip/RMT/Tests/Functional/RMTFunctionalTestBase.php
@@ -11,9 +11,10 @@
 
 namespace Liip\RMT\Tests\Functional;
 
+use Liip\RMT\Changelog\ChangelogManager;
 use Symfony\Component\Yaml\Yaml;
 
-class RMTFunctionalTestBase extends \PHPUnit\Framework\TestCase
+class RMTFunctionalTestBase extends ForwardCompatibilityTestCase
 {
     protected $tempDir;
 
@@ -32,7 +33,7 @@ class RMTFunctionalTestBase extends \PHPUnit\Framework\TestCase
         exec("php $rmtDir/command.php init --configonly=n --generator=basic-increment --persister=vcs-tag --vcs=git");
     }
 
-    protected function createConfig($generator, $persister, $otherConfig = array())
+    protected function createConfig($generator, $persister, $otherConfig = array()): void
     {
         $allConfig = array_merge($otherConfig, array(
             'version-persister' => $persister,
@@ -41,14 +42,14 @@ class RMTFunctionalTestBase extends \PHPUnit\Framework\TestCase
         file_put_contents('.rmt.yml', Yaml::dump($allConfig));
     }
 
-    protected function createChangelog($format)
+    protected function createChangelog($format): void
     {
         $file = $this->tempDir . '/CHANGELOG';
-        $manager = new \Liip\RMT\Changelog\ChangelogManager($file, $format);
+        $manager = new ChangelogManager($file, $format);
         $manager->update(
-            $format == 'semantic' ? '0.0.1' : '1',
+            $format === 'semantic' ? '0.0.1' : '1',
             'First release',
-            $format == 'semantic' ? array('type' => 'patch') : null
+            $format === 'semantic' ? array('type' => 'patch') : null
         );
     }
 
@@ -57,14 +58,14 @@ class RMTFunctionalTestBase extends \PHPUnit\Framework\TestCase
         exec('rm -rf ' . $this->tempDir);
     }
 
-    protected function initGit()
+    protected function initGit(): void
     {
         exec('git init');
         exec('git add .');
         exec('git commit -m "First commit"');
     }
 
-    protected function manualDebug()
+    protected function manualDebug(): void
     {
         echo "\n\nMANUAL DEBUG Go to:\n > cd " . $this->tempDir . "\n\n";
         exit();

--- a/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
+++ b/test/Liip/RMT/Tests/Functional/TestsCheckTest.php
@@ -2,18 +2,21 @@
 
 namespace Liip\RMT\Tests\Functional;
 
-use Exception;
 use Liip\RMT\Context;
 use Liip\RMT\Prerequisite\TestsCheck;
+use Liip\RMT\Information\InformationCollector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
-class TestsCheckTest extends \PHPUnit\Framework\TestCase
+class TestsCheckTest extends TestCase
 {
     protected function setUp(): void
     {
-        $informationCollector = $this->createMock('Liip\RMT\Information\InformationCollector');
+        $informationCollector = $this->createMock(InformationCollector::class);
         $informationCollector->method('getValueFor')->with(TestsCheck::SKIP_OPTION)->willReturn(false);
 
-        $output = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+        $output = $this->createMock(OutputInterface::class);
         $output->method('write');
 
         $context = Context::getInstance();
@@ -25,7 +28,7 @@ class TestsCheckTest extends \PHPUnit\Framework\TestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function succeeds_when_command_finished_within_the_default_configured_timeout_of_60s()
+    public function succeeds_when_command_finished_within_the_default_configured_timeout_of_60s(): void
     {
         $check = new TestsCheck(array('command' => 'echo OK'));
         $check->execute();
@@ -35,7 +38,7 @@ class TestsCheckTest extends \PHPUnit\Framework\TestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function succeeds_when_command_finished_within_configured_timeout()
+    public function succeeds_when_command_finished_within_configured_timeout(): void
     {
         $check = new TestsCheck(array('command' => 'echo OK', 'timeout' => 0.100));
         $check->execute();
@@ -44,10 +47,11 @@ class TestsCheckTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function fails_when_the_command_exceeds_the_timeout()
+    public function fails_when_the_command_exceeds_the_timeout(): void
     {
-        $this->expectException('Exception');
-        $this->expectExceptionMessage('~process.*time.*out~');
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessageMatches('~process.*time.*out~');
+
         $check = new TestsCheck(array('command' => 'sleep 1', 'timeout' => 0.100));
         $check->execute();
     }

--- a/test/Liip/RMT/Tests/Unit/Changelog/ChangelogManagerTest.php
+++ b/test/Liip/RMT/Tests/Unit/Changelog/ChangelogManagerTest.php
@@ -12,22 +12,25 @@
 namespace Liip\RMT\Tests\Unit\Changelog;
 
 use Liip\RMT\Changelog\ChangelogManager;
+use Liip\RMT\Exception;
+use PHPUnit\Framework\TestCase;
 
-class ChangelogManagerTest extends \PHPUnit\Framework\TestCase
+class ChangelogManagerTest extends TestCase
 {
     protected $dir;
 
-    public function testAutoFileCreationWhenNoFound()
+    public function testAutoFileCreationWhenNoFound(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'CHANGELOG');
         new ChangelogManager($file, 'semantic');
-        $this->assertFileExists($file);
+        self::assertFileExists($file);
         unlink($file);
     }
 
-    public function testExceptionWhenNotAbleToCreate()
+    public function testExceptionWhenNotAbleToCreate(): void
     {
-        $this->expectException('Liip\RMT\Exception');
+        $this->expectException(Exception::class);
+
         $this->dir = sys_get_temp_dir() . '/' . md5(time());
         mkdir($this->dir);
         new ChangelogManager($this->dir, 'semantic');

--- a/test/Liip/RMT/Tests/Unit/Changelog/Formatter/MarkdownChangelogFormatterTest.php
+++ b/test/Liip/RMT/Tests/Unit/Changelog/Formatter/MarkdownChangelogFormatterTest.php
@@ -11,22 +11,23 @@
 
 namespace Liip\RMT\Tests\Unit\Changelog\Formatter;
 
-class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\TestCase;
+use Liip\RMT\Changelog\Formatter\MarkdownChangelogFormatter;
+
+class MarkdownChangelogFormatterTest extends TestCase
 {
-    /**
-     * @return Liip\RMT\Changelog\Formatter\SemanticChangelogFormatter
-     */
-    protected function getFormatter()
+    protected function getFormatter(): MarkdownChangelogFormatter
     {
         $formatter = $this
-            ->getMockBuilder('Liip\RMT\Changelog\Formatter\MarkdownChangelogFormatter')
-            ->setMethods(array('getFormattedDate'))
+            ->getMockBuilder(MarkdownChangelogFormatter::class)
+            ->{method_exists(MockBuilder::class, 'onlyMethods') ? 'onlyMethods' : 'setMethods'}(['getFormattedDate'])
             ->getMock()
         ;
+
         $formatter
-            ->expects($this->any())
             ->method('getFormattedDate')
-            ->will($this->returnValue('1980-11-08 12:34'))
+            ->willReturn('1980-11-08 12:34')
         ;
 
         return $formatter;
@@ -35,38 +36,38 @@ class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getDataForFirstReleaseTest
      */
-    public function testFirstRelease($version, $type, $results)
+    public function testFirstRelease($version, $type, $results): void
     {
         $formatter = $this->getFormatter();
-        $lines = $formatter->updateExistingLines(array(), $version, 'foo bar', array('type' => $type));
-        $this->assertEquals($results, $lines);
+        $lines = $formatter->updateExistingLines([], $version, 'foo bar', ['type' => $type]);
+        self::assertEquals($results, $lines);
     }
 
-    public function getDataForFirstReleaseTest()
+    public function getDataForFirstReleaseTest(): array
     {
-        return array(
-            array('0.0.1', 'patch', array('', '## VERSION 0  FOO BAR', '', ' * Version **0.0** - foo bar', '   * 1980-11-08 12:34  **0.0.1**  initial release')),
-            array('0.1.0', 'patch', array('', '## VERSION 0  FOO BAR', '', ' * Version **0.1** - foo bar', '   * 1980-11-08 12:34  **0.1.0**  initial release')),
-            array('1.0.0', 'patch', array('', '## VERSION 1  FOO BAR', '', ' * Version **1.0** - foo bar', '   * 1980-11-08 12:34  **1.0.0**  initial release')),
-        );
+        return [
+            ['0.0.1', 'patch', ['', '## VERSION 0  FOO BAR', '', ' * Version **0.0** - foo bar', '   * 1980-11-08 12:34  **0.0.1**  initial release']],
+            ['0.1.0', 'patch', ['', '## VERSION 0  FOO BAR', '', ' * Version **0.1** - foo bar', '   * 1980-11-08 12:34  **0.1.0**  initial release']],
+            ['1.0.0', 'patch', ['', '## VERSION 1  FOO BAR', '', ' * Version **1.0** - foo bar', '   * 1980-11-08 12:34  **1.0.0**  initial release']],
+        ];
     }
 
-    public function testExtraLines()
+    public function testExtraLines(): void
     {
         $formatter = $this->getFormatter();
-        $lines = $formatter->updateExistingLines(array(
+        $lines = $formatter->updateExistingLines([
             '',
             '## VERSION 1  FOO BAR',
             '',
             ' * Version **1.0** - foo bar',
             '   * 1980-11-08 12:34  **1.0.0**  initial release',
 
-        ), '1.0.1', 'foo bar', array('type' => 'patch', 'extra-lines' => array(
+        ], '1.0.1', 'foo bar', ['type' => 'patch', 'extra-lines' => [
             'ada96f3 Add new tests for command RMT init and RMT current ref #10',
             '2eb6fae Documentation review',
-        )));
+        ]]);
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             '## VERSION 1  FOO BAR',
             '',
@@ -75,51 +76,51 @@ class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
             '      * ada96f3 Add new tests for command RMT init and RMT current ref #10',
             '      * 2eb6fae Documentation review',
             '   * 1980-11-08 12:34  **1.0.0**  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithPatch()
+    public function testUpdateExistingWithPatch(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 '## VERSION 1  FOO BAR',
                 '',
                 ' * Version **1.0** - foo bar',
                 '   * 1980-11-08 12:34  **1.0.0**  initial release',
-            ),
+            ],
             '1.0.1',
             'foofoo',
-            array('type' => 'patch')
+            ['type' => 'patch']
         );
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             '## VERSION 1  FOO BAR',
             '',
             ' * Version **1.0** - foo bar',
             '   * 1980-11-08 12:34  **1.0.1**  foofoo',
             '   * 1980-11-08 12:34  **1.0.0**  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithMinor()
+    public function testUpdateExistingWithMinor(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 '## VERSION 1  FOO BAR',
                 '',
                 ' * Version **1.0** - foo bar',
                 '   * 1980-11-08 12:34  **1.0.0**  initial release',
-            ),
+            ],
             '1.1.0',
             'foofoo',
-            array('type' => 'minor')
+            ['type' => 'minor']
         );
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             '## VERSION 1  FOO BAR',
             '',
@@ -128,26 +129,26 @@ class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
             '',
             ' * Version **1.0** - foo bar',
             '   * 1980-11-08 12:34  **1.0.0**  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithMajor()
+    public function testUpdateExistingWithMajor(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 '## VERSION 1  FOO BAR',
                 '',
                 ' * Version **1.0** - foo bar',
                 '   * 1980-11-08 12:34  **1.0.0**  initial release',
-            ),
+            ],
             '2.0.0',
             'foofoo',
-            array('type' => 'major')
+            ['type' => 'major']
         );
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             '## VERSION 2  FOOFOO',
             '',
@@ -158,6 +159,6 @@ class MarkdownChangelogFormatter extends \PHPUnit\Framework\TestCase
             '',
             ' * Version **1.0** - foo bar',
             '   * 1980-11-08 12:34  **1.0.0**  initial release',
-        ), $lines);
+        ], $lines);
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Changelog/Formatter/SemanticChangelogFormatterTest.php
+++ b/test/Liip/RMT/Tests/Unit/Changelog/Formatter/SemanticChangelogFormatterTest.php
@@ -11,22 +11,23 @@
 
 namespace Liip\RMT\Tests\Unit\Changelog\Formatter;
 
-class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
+use Liip\RMT\Changelog\Formatter\SemanticChangelogFormatter;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\TestCase;
+
+class SemanticChangelogFormatterTest extends TestCase
 {
-    /**
-     * @return Liip\RMT\Changelog\Formatter\SemanticChangelogFormatter
-     */
-    protected function getFormatter()
+    protected function getFormatter(): SemanticChangelogFormatter
     {
         $formatter = $this
-            ->getMockBuilder('Liip\RMT\Changelog\Formatter\SemanticChangelogFormatter')
-            ->setMethods(array('getFormattedDate'))
+            ->getMockBuilder(SemanticChangelogFormatter::class)
+            ->{method_exists(MockBuilder::class, 'onlyMethods') ? 'onlyMethods' : 'setMethods'}(['getFormattedDate'])
             ->getMock()
         ;
+
         $formatter
-            ->expects($this->any())
             ->method('getFormattedDate')
-            ->will($this->returnValue('08/11/1980 12:34'))
+            ->willReturn('08/11/1980 12:34')
         ;
 
         return $formatter;
@@ -35,26 +36,26 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getDataForFirstReleaseTest
      */
-    public function testFirstRelease($version, $type, $results)
+    public function testFirstRelease($version, $type, $results): void
     {
         $formatter = $this->getFormatter();
-        $lines = $formatter->updateExistingLines(array(), $version, 'foo bar', array('type' => $type));
-        $this->assertEquals($results, $lines);
+        $lines = $formatter->updateExistingLines([], $version, 'foo bar', ['type' => $type]);
+        self::assertEquals($results, $lines);
     }
 
-    public function getDataForFirstReleaseTest()
+    public function getDataForFirstReleaseTest(): array
     {
-        return array(
-            array('0.0.1', 'patch', array('', 'VERSION 0  FOO BAR', '==================', '', '   Version 0.0 - foo bar', '      08/11/1980 12:34  0.0.1  initial release')),
-            array('0.1.0', 'patch', array('', 'VERSION 0  FOO BAR', '==================', '', '   Version 0.1 - foo bar', '      08/11/1980 12:34  0.1.0  initial release')),
-            array('1.0.0', 'patch', array('', 'VERSION 1  FOO BAR', '==================', '', '   Version 1.0 - foo bar', '      08/11/1980 12:34  1.0.0  initial release')),
-        );
+        return [
+            ['0.0.1', 'patch', ['', 'VERSION 0  FOO BAR', '==================', '', '   Version 0.0 - foo bar', '      08/11/1980 12:34  0.0.1  initial release']],
+            ['0.1.0', 'patch', ['', 'VERSION 0  FOO BAR', '==================', '', '   Version 0.1 - foo bar', '      08/11/1980 12:34  0.1.0  initial release']],
+            ['1.0.0', 'patch', ['', 'VERSION 1  FOO BAR', '==================', '', '   Version 1.0 - foo bar', '      08/11/1980 12:34  1.0.0  initial release']],
+        ];
     }
 
-    public function testExtraLines()
+    public function testExtraLines(): void
     {
         $formatter = $this->getFormatter();
-        $lines = $formatter->updateExistingLines(array(
+        $lines = $formatter->updateExistingLines([
             '',
             'VERSION 1  FOO BAR',
             '==================',
@@ -62,12 +63,12 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
             '   Version 1.0 - foo bar',
             '      08/11/1980 12:34  1.0.0  initial release',
 
-        ), '1.0.1', 'foo bar', array('type' => 'patch', 'extra-lines' => array(
+        ], '1.0.1', 'foo bar', ['type' => 'patch', 'extra-lines' => [
             'ada96f3 Add new tests for command RMT init and RMT current ref #10',
             '2eb6fae Documentation review',
-        )));
+        ]]);
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             'VERSION 1  FOO BAR',
             '==================',
@@ -77,27 +78,27 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
             '         ada96f3 Add new tests for command RMT init and RMT current ref #10',
             '         2eb6fae Documentation review',
             '      08/11/1980 12:34  1.0.0  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithPatch()
+    public function testUpdateExistingWithPatch(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 'VERSION 1  FOO BAR',
                 '==================',
                 '',
                 '   Version 1.0 - foo bar',
                 '      08/11/1980 12:34  1.0.0  initial release',
-            ),
+            ],
             '1.0.1',
             'foofoo',
-            array('type' => 'patch')
+            ['type' => 'patch']
         );
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             'VERSION 1  FOO BAR',
             '==================',
@@ -105,26 +106,26 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
             '   Version 1.0 - foo bar',
             '      08/11/1980 12:34  1.0.1  foofoo',
             '      08/11/1980 12:34  1.0.0  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithMinor()
+    public function testUpdateExistingWithMinor(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 'VERSION 1  FOO BAR',
                 '==================',
                 '',
                 '   Version 1.0 - foo bar',
                 '      08/11/1980 12:34  1.0.0  initial release',
-            ),
+            ],
             '1.1.0',
             'foofoo',
-            array('type' => 'minor')
+            ['type' => 'minor']
         );
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             'VERSION 1  FOO BAR',
             '==================',
@@ -134,27 +135,27 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
             '',
             '   Version 1.0 - foo bar',
             '      08/11/1980 12:34  1.0.0  initial release',
-        ), $lines);
+        ], $lines);
     }
 
-    public function testUpdateExistingWithMajor()
+    public function testUpdateExistingWithMajor(): void
     {
         $formatter = $this->getFormatter();
         $lines = $formatter->updateExistingLines(
-            array(
+            [
                 '',
                 'VERSION 1  FOO BAR',
                 '==================',
                 '',
                 '   Version 1.0 - foo bar',
                 '      08/11/1980 12:34  1.0.0  initial release',
-            ),
+            ],
             '2.0.0',
             'foofoo',
-            array('type' => 'major')
+            ['type' => 'major']
         );
 
-        $this->assertEquals(array(
+        self::assertEquals([
             '',
             'VERSION 2  FOOFOO',
             '=================',
@@ -167,6 +168,6 @@ class SemanticChangelogFormatterTest extends \PHPUnit\Framework\TestCase
             '',
             '   Version 1.0 - foo bar',
             '      08/11/1980 12:34  1.0.0  initial release',
-        ), $lines);
+        ], $lines);
     }
 }

--- a/test/Liip/RMT/Tests/Unit/ContextTest.php
+++ b/test/Liip/RMT/Tests/Unit/ContextTest.php
@@ -11,118 +11,127 @@
 
 namespace Liip\RMT\Tests\Unit;
 
+use InvalidArgumentException;
 use Liip\RMT\Context;
+use PHPUnit\Framework\TestCase;
+use Liip\RMT\Tests\Unit\ServiceClass;
 
-class ContextTest extends \PHPUnit\Framework\TestCase
+class ContextTest extends TestCase
 {
     // SERVICE TESTS
 
-    public function testSetAndGetService()
+    public function testSetAndGetService(): void
     {
         $context = Context::getInstance();
-        $context->setService('foo', '\Liip\RMT\Tests\Unit\ServiceClass');
+        $context->setService('foo', ServiceClass::class);
         $objectFoo = $context->getService('foo');
-        $this->assertInstanceOf('\Liip\RMT\Tests\Unit\ServiceClass', $objectFoo);
-        $this->assertEquals($objectFoo, $context->getService('foo'), 'Two successive calls return the same object');
+        self::assertInstanceOf(ServiceClass::class, $objectFoo);
+        self::assertEquals($objectFoo, $context->getService('foo'), 'Two successive calls return the same object');
     }
 
-    public function testSetAndGetServiceWithObject()
+    public function testSetAndGetServiceWithObject(): void
     {
         $context = Context::getInstance();
         $object = new ServiceClass();
         $context->setService('foo', $object);
-        $this->assertEquals($object, $context->getService('foo'));
+        self::assertEquals($object, $context->getService('foo'));
     }
 
-    public function testSetAndGetServiceWithOptions()
+    public function testSetAndGetServiceWithOptions(): void
     {
         $context = Context::getInstance();
-        $options = array('pi' => 3.14);
-        $context->setService('foo', '\Liip\RMT\Tests\Unit\ServiceClass', $options);
-        $this->assertEquals($options, $context->getService('foo')->getOptions());
+        $options = ['pi' => 3.14];
+        $context->setService('foo', ServiceClass::class, $options);
+        self::assertEquals($options, $context->getService('foo')->getOptions());
     }
 
-    public function testGetServiceWithoutSet()
+    public function testGetServiceWithoutSet(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('There is no service defined with id [abc]');
+
         Context::getInstance()->getService('abc');
     }
 
-    public function testSetServiceWithInvalidClass()
+    public function testSetServiceWithInvalidClass(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class [Bar] does not exist');
+
         Context::getInstance()->setService('foo', 'Bar');
     }
 
-    public function testSetServiceWithInvalidObject()
+    public function testSetServiceWithInvalidObject(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('setService() only accept an object or a valid class name');
+
         $context = Context::getInstance();
         $context->setService('foo', 12);
     }
 
     // PARAM TESTS
 
-    public function testSetAndGetParam()
+    public function testSetAndGetParam(): void
     {
         $context = Context::getInstance();
         $context->setParameter('date', '11.11.11');
-        $this->assertEquals('11.11.11', $context->getParameter('date'));
+        self::assertEquals('11.11.11', $context->getParameter('date'));
     }
 
-    public function testGetParamWithoutSet()
+    public function testGetParamWithoutSet(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('There is no param defined with id [abc]');
+
         $context = Context::getInstance();
         $context->getParameter('abc');
     }
 
     // LIST TESTS
 
-    public function testAddToList()
+    public function testAddToList(): void
     {
         $context = Context::getInstance();
-        $context->addToList('prerequisites', '\Liip\RMT\Tests\Unit\ServiceClass');
-        $context->addToList('prerequisites', '\Liip\RMT\Context');
+        $context->addToList('prerequisites', ServiceClass::class);
+        $context->addToList('prerequisites', Context::class);
         $objects = $context->getList('prerequisites');
-        $this->assertCount(2, $objects);
-        $this->assertInstanceOf('\Liip\RMT\Tests\Unit\ServiceClass', $objects[0]);
-        $this->assertInstanceOf('\Liip\RMT\Context', $objects[1]);
+        self::assertCount(2, $objects);
+        self::assertInstanceOf(ServiceClass::class, $objects[0]);
+        self::assertInstanceOf(Context::class, $objects[1]);
     }
 
-    public function testAddToListWithOptions()
+    public function testAddToListWithOptions(): void
     {
         $context = Context::getInstance();
         $options = array('pi' => 3.14);
-        $context->addToList('foo', '\Liip\RMT\Tests\Unit\ServiceClass', $options);
+        $context->addToList('foo', ServiceClass::class, $options);
         $objects = $context->getList('foo');
-        $this->assertEquals($options, $objects[0]->getOptions());
+        self::assertEquals($options, $objects[0]->getOptions());
     }
 
-    public function testGetListParamWithoutAdd()
+    public function testGetListParamWithoutAdd(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('There is no list defined with id [abc]');
+
         $context = Context::getInstance();
         $context->getList('abc');
     }
 
-    public function testAddToListWithInvalidClass()
+    public function testAddToListWithInvalidClass(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The class [Bar] does not exist');
+
         $context = Context::getInstance();
         $context->addToList('foo', 'Bar');
     }
 
-    public function testEmptyList()
+    public function testEmptyList(): void
     {
         $context = Context::getInstance();
         $context->createEmptyList('prerequisites');
-        $this->assertEquals(array(), $context->getList('prerequisites'));
+        self::assertEquals(array(), $context->getList('prerequisites'));
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Information/InformationCollectorTest.php
+++ b/test/Liip/RMT/Tests/Unit/Information/InformationCollectorTest.php
@@ -13,46 +13,47 @@ namespace Liip\RMT\Tests\Unit\Information;
 
 use Liip\RMT\Information\InformationCollector;
 use Liip\RMT\Information\InformationRequest;
+use PHPUnit\Framework\TestCase;
 
-class InformationCollectorTest extends \PHPUnit\Framework\TestCase
+class InformationCollectorTest extends TestCase
 {
-    public function testRegisterRequest()
+    public function testRegisterRequest(): void
     {
         $ic = new InformationCollector();
-        $this->assertFalse($ic->hasRequest('foo'));
+        self::assertFalse($ic->hasRequest('foo'));
         $ic->registerRequest(new InformationRequest('foo'));
-        $this->assertTrue($ic->hasRequest('foo'));
+        self::assertTrue($ic->hasRequest('foo'));
     }
 
-    public function testRegisterRequests()
+    public function testRegisterRequests(): void
     {
         $ic = new InformationCollector();
-        $this->assertFalse($ic->hasRequest('foo') || $ic->hasRequest('type'));
+        self::assertFalse($ic->hasRequest('foo') || $ic->hasRequest('type'));
         $ic->registerRequests(array(new InformationRequest('foo'), 'type'));
-        $this->assertTrue($ic->hasRequest('foo'));
-        $this->assertTrue($ic->hasRequest('type'));
+        self::assertTrue($ic->hasRequest('foo'));
+        self::assertTrue($ic->hasRequest('type'));
     }
 
-    public function testHasMissingInformation()
+    public function testHasMissingInformation(): void
     {
         $ic = new InformationCollector();
         $ic->registerRequest(new InformationRequest('foo'));
-        $this->assertTrue($ic->hasMissingInformation());
+        self::assertTrue($ic->hasMissingInformation());
         $ic->setValueFor('foo', 'bar');
-        $this->assertFalse($ic->hasMissingInformation());
+        self::assertFalse($ic->hasMissingInformation());
     }
 
-    public function testSetAndGetValueFor()
+    public function testSetAndGetValueFor(): void
     {
         $ic = new InformationCollector();
         $ic->registerRequest(new InformationRequest('foo'));
         $ic->setValueFor('foo', 'bar');
-        $this->assertEquals('bar', $ic->getValueFor('foo'));
+        self::assertEquals('bar', $ic->getValueFor('foo'));
     }
 
-    public function testGetValueForWithDefault()
+    public function testGetValueForWithDefault(): void
     {
         $ic = new InformationCollector();
-        $this->assertEquals('bar', $ic->getValueFor('foo', 'bar'));
+        self::assertEquals('bar', $ic->getValueFor('foo', 'bar'));
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Information/InformationRequestTest.php
+++ b/test/Liip/RMT/Tests/Unit/Information/InformationRequestTest.php
@@ -11,66 +11,69 @@
 
 namespace Liip\RMT\Tests\Unit\Information;
 
+use InvalidArgumentException;
 use Liip\RMT\Information\InformationRequest;
+use PHPUnit\Framework\TestCase;
 
-class InformationRequestTest extends \PHPUnit\Framework\TestCase
+class InformationRequestTest extends TestCase
 {
-    public function testSetAndGetValue()
+    public function testSetAndGetValue(): void
     {
-        $ir = new InformationRequest('foo', array('type' => 'text'));
-        $this->assertFalse($ir->hasValue());
+        $ir = new InformationRequest('foo', ['type' => 'text']);
+        self::assertFalse($ir->hasValue());
         $ir->setValue('bar');
-        $this->assertTrue($ir->hasValue());
-        $this->assertEquals('bar', $ir->getValue());
+        self::assertTrue($ir->hasValue());
+        self::assertEquals('bar', $ir->getValue());
     }
 
     /**
      * @dataProvider getDataForValidationSuccess
      */
-    public function testValidationSuccess($options, $value, $expected = null)
+    public function testValidationSuccess(array $options, $value, ?string $expected = null): void
     {
-        if (func_num_args() == 2) {
+        if (func_num_args() === 2) {
             $expected = $value;
         }
         $ir = new InformationRequest('foo', $options);
         $ir->setValue($value);
-        $this->assertEquals($expected, $ir->getValue());
+        self::assertEquals($expected, $ir->getValue());
     }
 
-    public function getDataForValidationSuccess()
+    public function getDataForValidationSuccess(): array
     {
-        return array(
-            array(array('type' => 'text'), 'string'),
-            array(array('type' => 'yes-no'), 'y'),
-            array(array('type' => 'yes-no'), 'n'),
-            array(array('type' => 'yes-no'), 'yes', 'y'),
-            array(array('type' => 'yes-no'), 'no' , 'n'),
-            array(array('type' => 'choice', 'choices' => array('apple', 'banana', 'cherry')), 'apple'),
-            array(array('type' => 'confirmation'), true),
-            array(array('type' => 'confirmation'), false),
-        );
+        return [
+            [['type' => 'text'], 'string'],
+            [['type' => 'yes-no'], 'y'],
+            [['type' => 'yes-no'], 'n'],
+            [['type' => 'yes-no'], 'yes', 'y'],
+            [['type' => 'yes-no'], 'no' , 'n'],
+            [['type' => 'choice', 'choices' => ['apple', 'banana', 'cherry']], 'apple'],
+            [['type' => 'confirmation'], true],
+            [['type' => 'confirmation'], false],
+        ];
     }
 
     /**
      * @dataProvider getDataForValidationFail
      */
-    public function testValidationFail($options, $value)
+    public function testValidationFail(array $options, $value): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
+
         $ir = new InformationRequest('foo', $options);
         $ir->setValue($value);
     }
 
-    public function getDataForValidationFail()
+    public function getDataForValidationFail(): array
     {
-        $choices = array('apple', 'banana', 'cherry');
+        $choices = ['apple', 'banana', 'cherry'];
 
-        return array(
-            array(array('type' => 'text'), true),
-            array(array('type' => 'text'), ''),
-            array(array('type' => 'yes-no'), 'foo'),
-            array(array('type' => 'yes-no'), 19),
-            array(array('type' => 'choice', 'choices' => $choices), 'mango'),
-        );
+        return [
+            [['type' => 'text'], true],
+            [['type' => 'text'], ''],
+            [['type' => 'yes-no'], 'foo'],
+            [['type' => 'yes-no'], 19],
+            [['type' => 'choice', 'choices' => $choices], 'mango'],
+        ];
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Information/InteractiveQuestionTest.php
+++ b/test/Liip/RMT/Tests/Unit/Information/InteractiveQuestionTest.php
@@ -13,35 +13,36 @@ namespace Liip\RMT\Tests\Unit\Information;
 
 use Liip\RMT\Information\InformationRequest;
 use Liip\RMT\Information\InteractiveQuestion;
+use PHPUnit\Framework\TestCase;
 
-class InteractiveQuestionTest extends \PHPUnit\Framework\TestCase
+class InteractiveQuestionTest extends TestCase
 {
-    public function testGetDefault()
+    public function testGetDefault(): void
     {
         $iq = new InteractiveQuestion(new InformationRequest('foo'));
-        $this->assertFalse($iq->hasDefault());
+        self::assertFalse($iq->hasDefault());
 
-        $iq = new InteractiveQuestion(new InformationRequest('foo', array('default' => 'bar')));
-        $this->assertEquals('bar', $iq->getDefault());
+        $iq = new InteractiveQuestion(new InformationRequest('foo', ['default' => 'bar']));
+        self::assertEquals('bar', $iq->getDefault());
 
-        $iq = new InteractiveQuestion(new InformationRequest('fruit', array(
+        $iq = new InteractiveQuestion(new InformationRequest('fruit', [
             'type' => 'choice',
-            'choices' => array('apple', 'banana', 'cherry'),
-            'choices_shortcuts' => array('a' => 'apple', 'b' => 'banana', 'c' => 'cherry'),
+            'choices' => ['apple', 'banana', 'cherry'],
+            'choices_shortcuts' => ['a' => 'apple', 'b' => 'banana', 'c' => 'cherry'],
             'default' => 'banana',
-        )));
-        $this->assertEquals('b', $iq->getDefault());
+        ]));
+        self::assertEquals('b', $iq->getDefault());
     }
 
-    public function testValidateChoicesWithShortcuts()
+    public function testValidateChoicesWithShortcuts(): void
     {
-        $ir = new InformationRequest('fruit', array(
+        $ir = new InformationRequest('fruit', [
             'type' => 'choice',
-            'choices' => array('apple', 'banana', 'cherry'),
-            'choices_shortcuts' => array('a' => 'apple', 'b' => 'banana', 'c' => 'cherry'),
-        ));
+            'choices' => ['apple', 'banana', 'cherry'],
+            'choices_shortcuts' => ['a' => 'apple', 'b' => 'banana', 'c' => 'cherry'],
+        ]);
 
         $iq = new InteractiveQuestion($ir);
-        $this->assertEquals('apple', $iq->validate('a'));
+        self::assertEquals('apple', $iq->validate('a'));
     }
 }

--- a/test/Liip/RMT/Tests/Unit/VCS/GitTest.php
+++ b/test/Liip/RMT/Tests/Unit/VCS/GitTest.php
@@ -11,9 +11,11 @@
 
 namespace Liip\RMT\Tests\Unit\Version;
 
+use Liip\RMT\Exception;
 use Liip\RMT\VCS\Git;
+use PHPUnit\Framework\TestCase;
 
-class GitTest extends \PHPUnit\Framework\TestCase
+class GitTest extends TestCase
 {
     protected $testDir;
 
@@ -31,72 +33,73 @@ class GitTest extends \PHPUnit\Framework\TestCase
         $this->testDir = $tempDir;
     }
 
-    public function testGetAllModificationsSince()
+    public function testGetAllModificationsSince(): void
     {
         $vcs = new Git();
         $modifs = $vcs->getAllModificationsSince('1.1.0');
-        $this->assertContains('Add a third file', $modifs[0]);
-        $this->assertContains('Modification of the first file', $modifs[1]);
+        self::assertStringContainsString('Add a third file', $modifs[0]);
+        self::assertStringContainsString('Modification of the first file', $modifs[1]);
     }
 
-    public function testGetModifiedFilesSince()
+    public function testGetModifiedFilesSince(): void
     {
         $vcs = new Git();
         $files = $vcs->getModifiedFilesSince('1.1.0');
-        $this->assertEquals(array('file1' => 'M', 'file3' => 'A'), $files);
+        self::assertEquals(['file1' => 'M', 'file3' => 'A'], $files);
     }
 
-    public function testGetLocalModifications()
+    public function testGetLocalModifications(): void
     {
         $vcs = new Git();
         exec('touch foo');
         $modifs = $vcs->getLocalModifications();
-        $this->assertContains('foo', implode($modifs));
+        self::assertStringContainsString('foo', implode($modifs));
     }
 
-    public function testGetTags()
+    public function testGetTags(): void
     {
         $vcs = new Git();
-        $this->assertEquals(array('1.0.0', '1.1.0'), $vcs->getTags());
+        self::assertEquals(['1.0.0', '1.1.0'], $vcs->getTags());
     }
 
-    public function testCreateTag()
-    {
-        $vcs = new Git();
-        $vcs->createTag('2.0.0');
-        $this->assertEquals(array('1.0.0', '1.1.0', '2.0.0'), $vcs->getTags());
-    }
-
-    public function testSaveWorkingCopy()
+    public function testCreateTag(): void
     {
         $vcs = new Git();
         $vcs->createTag('2.0.0');
-        $this->assertEquals(array(), $vcs->getAllModificationsSince('2.0.0'));
+        self::assertEquals(['1.0.0', '1.1.0', '2.0.0'], $vcs->getTags());
+    }
+
+    public function testSaveWorkingCopy(): void
+    {
+        $vcs = new Git();
+        $vcs->createTag('2.0.0');
+        self::assertEquals([], $vcs->getAllModificationsSince('2.0.0'));
         exec('rm file2');
         $vcs->saveWorkingCopy('Remove the second file');
-        $this->assertCount(1, $vcs->getAllModificationsSince('2.0.0'));
+        self::assertCount(1, $vcs->getAllModificationsSince('2.0.0'));
     }
 
-    public function testGetCurrentBranch()
+    public function testGetCurrentBranch(): void
     {
         $vcs = new Git();
-        $this->assertEquals('master', $vcs->getCurrentBranch());
+        self::assertEquals('master', $vcs->getCurrentBranch());
         system('git checkout -b foo --quiet');
-        $this->assertEquals('foo', $vcs->getCurrentBranch());
+        self::assertEquals('foo', $vcs->getCurrentBranch());
         exec('git checkout master --quiet');
-        $this->assertEquals('master', $vcs->getCurrentBranch());
+        self::assertEquals('master', $vcs->getCurrentBranch());
     }
 
-    public function testGetCurrentBranchWhenNotInBranch()
+    public function testGetCurrentBranchWhenNotInBranch(): void
     {
-        $this->expectException('Liip\RMT\Exception');
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Not currently on any branch');
+
         $vcs = new Git();
         exec('git checkout 9aca70b --quiet');
         $vcs->getCurrentBranch();
     }
 
-    public function testChangeNoMergeCommits()
+    public function testChangeNoMergeCommits(): void
     {
         $vcs = new Git();
         exec('git checkout -b merge-branch --quiet');
@@ -106,12 +109,12 @@ class GitTest extends \PHPUnit\Framework\TestCase
 
         $modifs = $vcs->getAllModificationsSince('1.1.0', false, true);
 
-        $this->assertContains('First commit', $modifs[0]);
-        $this->assertContains('Add a third file', $modifs[1]);
-        $this->assertContains('Modification of the first file', $modifs[2]);
+        self::assertStringContainsString('First commit', $modifs[0]);
+        self::assertStringContainsString('Add a third file', $modifs[1]);
+        self::assertStringContainsString('Modification of the first file', $modifs[2]);
     }
 
-    public function testChangeWithMergeCommits()
+    public function testChangeWithMergeCommits(): void
     {
         $vcs = new Git();
         exec('git checkout -b merge-branch --quiet');
@@ -121,10 +124,10 @@ class GitTest extends \PHPUnit\Framework\TestCase
 
         $modifs = $vcs->getAllModificationsSince('1.1.0');
 
-        $this->assertContains("Merge branch 'merge-branch'", $modifs[0]);
-        $this->assertContains('First commit', $modifs[1]);
-        $this->assertContains('Add a third file', $modifs[2]);
-        $this->assertContains('Modification of the first file', $modifs[3]);
+        self::assertStringContainsString("Merge branch 'merge-branch'", $modifs[0]);
+        self::assertStringContainsString('First commit', $modifs[1]);
+        self::assertStringContainsString('Add a third file', $modifs[2]);
+        self::assertStringContainsString('Modification of the first file', $modifs[3]);
     }
 
     protected function tearDown(): void

--- a/test/Liip/RMT/Tests/Unit/VCS/HgTest.php
+++ b/test/Liip/RMT/Tests/Unit/VCS/HgTest.php
@@ -12,8 +12,9 @@
 namespace Liip\RMT\Tests\Unit\Version;
 
 use Liip\RMT\VCS\Hg;
+use PHPUnit\Framework\TestCase;
 
-class HgTest extends \PHPUnit\Framework\TestCase
+class HgTest extends TestCase
 {
     protected $testDir;
 
@@ -31,60 +32,60 @@ class HgTest extends \PHPUnit\Framework\TestCase
         $this->testDir = $tempDir;
     }
 
-    public function testGetAllModificationsSince()
+    public function testGetAllModificationsSince(): void
     {
         $vcs = new Hg();
         $modifs = $vcs->getAllModificationsSince('1.1.0');
-        $this->assertContains('Add a third file', $modifs[0]);
-        $this->assertContains('Modification of the first file', $modifs[1]);
+        self::assertStringContainsString('Add a third file', $modifs[0]);
+        self::assertStringContainsString('Modification of the first file', $modifs[1]);
     }
 
-    public function testGetModifiedFilesSince()
+    public function testGetModifiedFilesSince(): void
     {
         $vcs = new Hg();
         $files = $vcs->getModifiedFilesSince('1.1.0');
-        $this->assertEquals(array('file1' => 'M', 'file3' => 'A', '.hgtags' => 'M'), $files);
+        self::assertEquals(array('file1' => 'M', 'file3' => 'A', '.hgtags' => 'M'), $files);
     }
 
-    public function testGetLocalModifications()
+    public function testGetLocalModifications(): void
     {
         $vcs = new Hg();
         exec('touch foo');
         $modifs = $vcs->getLocalModifications();
-        $this->assertContains('foo', implode($modifs));
+        self::assertStringContainsString('foo', implode($modifs));
     }
 
-    public function testGetTags()
+    public function testGetTags(): void
     {
         $vcs = new Hg();
-        $this->assertEquals(array('tip', '1.1.0', '1.0.0'), $vcs->getTags());
+        self::assertEquals(['tip', '1.1.0', '1.0.0'], $vcs->getTags());
     }
 
-    public function testCreateTag()
-    {
-        $vcs = new Hg();
-        $vcs->createTag('2.0.0');
-        $this->assertEquals(array('tip', '2.0.0', '1.1.0', '1.0.0'), $vcs->getTags());
-    }
-
-    public function testSaveWorkingCopy()
+    public function testCreateTag(): void
     {
         $vcs = new Hg();
         $vcs->createTag('2.0.0');
-        $this->assertCount(1, $vcs->getAllModificationsSince('2.0.0'));
+        self::assertEquals(['tip', '2.0.0', '1.1.0', '1.0.0'], $vcs->getTags());
+    }
+
+    public function testSaveWorkingCopy(): void
+    {
+        $vcs = new Hg();
+        $vcs->createTag('2.0.0');
+        self::assertCount(1, $vcs->getAllModificationsSince('2.0.0'));
         exec('rm file2');
         $vcs->saveWorkingCopy('Remove the second file');
-        $this->assertCount(2, $vcs->getAllModificationsSince('2.0.0'));
+        self::assertCount(2, $vcs->getAllModificationsSince('2.0.0'));
     }
 
-    public function testGetCurrentBranch()
+    public function testGetCurrentBranch(): void
     {
         $vcs = new Hg();
-        $this->assertEquals('default', $vcs->getCurrentBranch());
+        self::assertEquals('default', $vcs->getCurrentBranch());
         system('hg branch -q foo');
-        $this->assertEquals('foo', $vcs->getCurrentBranch());
+        self::assertEquals('foo', $vcs->getCurrentBranch());
         exec('hg branch -q default');
-        $this->assertEquals('default', $vcs->getCurrentBranch());
+        self::assertEquals('default', $vcs->getCurrentBranch());
     }
 
     protected function tearDown(): void

--- a/test/Liip/RMT/Tests/Unit/Version/Generator/SemanticGeneratorTest.php
+++ b/test/Liip/RMT/Tests/Unit/Version/Generator/SemanticGeneratorTest.php
@@ -11,59 +11,64 @@
 
 namespace Liip\RMT\Tests\Unit\Version;
 
-class SemanticGeneratorTest extends \PHPUnit\Framework\TestCase
+use InvalidArgumentException;
+use Liip\RMT\Version\Generator\SemanticGenerator;
+use PHPUnit\Framework\TestCase;
+
+class SemanticGeneratorTest extends TestCase
 {
     /**
      * @dataProvider getVersionValues
      */
-    public function testIncrement($current, $type, $label, $result)
+    public function testIncrement(string $current, string $type, string $label, string $result): void
     {
-        $options = array(
+        $options = [
             'type' => $type,
             'label' => $label,
-        );
+        ];
 
-        $generator = new \Liip\RMT\Version\Generator\SemanticGenerator($options);
-        $this->assertEquals($result, $generator->generateNextVersion($current));
+        $generator = new SemanticGenerator($options);
+        self::assertEquals($result, $generator->generateNextVersion($current));
     }
 
-    public function getVersionValues()
+    public function getVersionValues(): array
     {
-        return array(
-            array('1.0.0',  'patch', 'none', '1.0.1'),
-            array('1.23.0', 'minor', 'none', '1.24.0'),
-            array('1.1.19', 'minor', 'none', '1.2.0'),
-            array('1.0.0',  'major', 'none', '2.0.0'),
-            array('1.19.3', 'major', 'none', '2.0.0'),
-            array('3.3.3',  'major', 'none', '4.0.0'),
-            array('3.3.3',  'major', 'alpha', '4.0.0-alpha'),
-            array('4.0.0-aplha2',  'major', 'beta', '4.0.0-beta'),
-            array('3.3.3',  'minor', 'beta', '3.4.0-beta'),
-            array('4.0.0-beta',  'minor', 'beta', '4.0.0-beta2'),
-            array('4.0.0',  'minor', 'rc', '4.1.0-rc'),
-            array('4.0.0-rc',  'minor', 'none', '4.0.0'),
-        );
+        return [
+            ['1.0.0',  'patch', 'none', '1.0.1'],
+            ['1.23.0', 'minor', 'none', '1.24.0'],
+            ['1.1.19', 'minor', 'none', '1.2.0'],
+            ['1.0.0',  'major', 'none', '2.0.0'],
+            ['1.19.3', 'major', 'none', '2.0.0'],
+            ['3.3.3',  'major', 'none', '4.0.0'],
+            ['3.3.3',  'major', 'alpha', '4.0.0-alpha'],
+            ['4.0.0-aplha2',  'major', 'beta', '4.0.0-beta'],
+            ['3.3.3',  'minor', 'beta', '3.4.0-beta'],
+            ['4.0.0-beta',  'minor', 'beta', '4.0.0-beta2'],
+            ['4.0.0',  'minor', 'rc', '4.1.0-rc'],
+            ['4.0.0-rc',  'minor', 'none', '4.0.0'],
+        ];
     }
 
-    public function testIncrementWithInvalidType()
+    public function testIncrementWithInvalidType(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The option [type] must be one of: {patch, minor, major}, "full" given');
-        $generator = new \Liip\RMT\Version\Generator\SemanticGenerator(array('type' => 'full', 'label' => 'none'));
+
+        $generator = new SemanticGenerator(array('type' => 'full', 'label' => 'none'));
         $generator->generateNextVersion('1.0.0');
     }
 
-    public function testCompare()
+    public function testCompare(): void
     {
-        $generator = new \Liip\RMT\Version\Generator\SemanticGenerator();
-        $this->assertEquals(-1, $generator->compareTwoVersions('1.0.0', '1.0.1'));
-        $this->assertEquals(-1, $generator->compareTwoVersions('1.0.0-beta', '1.0.0'));
-        $this->assertEquals(0, $generator->compareTwoVersions('1.0.0', '1.0.0'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.1', '1.0.0'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.11', '1.0.1'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.1', '1.0.1-alpha'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.1-beta', '1.0.1-alpha'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.11-rc', '1.0.1-beta'));
-        $this->assertEquals(1, $generator->compareTwoVersions('1.0.2', '1.0.1-rc'));
+        $generator = new SemanticGenerator();
+        self::assertEquals(-1, $generator->compareTwoVersions('1.0.0', '1.0.1'));
+        self::assertEquals(-1, $generator->compareTwoVersions('1.0.0-beta', '1.0.0'));
+        self::assertEquals(0, $generator->compareTwoVersions('1.0.0', '1.0.0'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.1', '1.0.0'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.11', '1.0.1'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.1', '1.0.1-alpha'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.1-beta', '1.0.1-alpha'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.11-rc', '1.0.1-beta'));
+        self::assertEquals(1, $generator->compareTwoVersions('1.0.2', '1.0.1-rc'));
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Version/Generator/SimpleGeneratorTest.php
+++ b/test/Liip/RMT/Tests/Unit/Version/Generator/SimpleGeneratorTest.php
@@ -11,11 +11,14 @@
 
 namespace Liip\RMT\Tests\Unit\Version;
 
-class SimpleGeneratorTest extends \PHPUnit\Framework\TestCase
+use Liip\RMT\Version\Generator\SimpleGenerator;
+use PHPUnit\Framework\TestCase;
+
+class SimpleGeneratorTest extends TestCase
 {
-    public function testIncrement()
+    public function testIncrement(): void
     {
-        $generator = new \Liip\RMT\Version\Generator\SimpleGenerator();
-        $this->assertEquals(4, $generator->generateNextVersion(3));
+        $generator = new SimpleGenerator();
+        self::assertEquals(4, $generator->generateNextVersion(3));
     }
 }

--- a/test/Liip/RMT/Tests/Unit/Version/Persister/TagValidatorTest.php
+++ b/test/Liip/RMT/Tests/Unit/Version/Persister/TagValidatorTest.php
@@ -12,44 +12,45 @@
 namespace Liip\RMT\Tests\Version\Persister;
 
 use Liip\RMT\Version\Persister\TagValidator;
+use PHPUnit\Framework\TestCase;
 
-class TagValidatorTest extends \PHPUnit\Framework\TestCase
+class TagValidatorTest extends TestCase
 {
     /**
      * @dataProvider getTagData
      */
-    public function testIsValid($tag, $result, $regex, $tagPrefix = '')
+    public function testIsValid(string $tag, bool $result, string $regex, string $tagPrefix = ''): void
     {
         $validator = new TagValidator($regex, $tagPrefix);
-        $this->assertEquals($result, $validator->isValid($tag));
+        self::assertEquals($result, $validator->isValid($tag));
     }
 
-    public function getTagData()
+    public function getTagData(): array
     {
         $simpleRegEx = '\d+';
         $semanticRegEx = '\d+\.\d+\.\d+';
 
-        return array(
-            array('1', true, $simpleRegEx),
-            array('23', true, $simpleRegEx),
-            array('3d', false, $simpleRegEx),
-            array('v_23', true, $simpleRegEx, 'v_'),
-            array('v-23',  false, $simpleRegEx, 'v_'),
-            array('v_3d',  false, $simpleRegEx, 'v_'),
-            array('1.0.3', true, $semanticRegEx),
-            array('3.0.3.7', false, $semanticRegEx),
-            array('3.b.3',  false, $semanticRegEx),
-            array('dev_3.3.3', true, $semanticRegEx, 'dev_'),
-            array('dev_3.3.3.7', false, $semanticRegEx, 'dev_'),
-        );
+        return [
+            ['1', true, $simpleRegEx],
+            ['23', true, $simpleRegEx],
+            ['3d', false, $simpleRegEx],
+            ['v_23', true, $simpleRegEx, 'v_'],
+            ['v-23',  false, $simpleRegEx, 'v_'],
+            ['v_3d',  false, $simpleRegEx, 'v_'],
+            ['1.0.3', true, $semanticRegEx],
+            ['3.0.3.7', false, $semanticRegEx],
+            ['3.b.3',  false, $semanticRegEx],
+            ['dev_3.3.3', true, $semanticRegEx, 'dev_'],
+            ['dev_3.3.3.7', false, $semanticRegEx, 'dev_'],
+        ];
     }
 
-    public function testFiltrateList()
+    public function testFiltrateList(): void
     {
         $validator = new TagValidator('\d');
-        $this->assertEquals(
-            array('1', '3'),
-            $validator->filtrateList(array('a', '1', '3s', '3'))
+        self::assertEquals(
+            ['1', '3'],
+            $validator->filtrateList(['a', '1', '3s', '3'])
         );
     }
 }


### PR DESCRIPTION
Fixed test execution with PHP 8.

PHP minimum version has been raised to 7.1 (the minimum version supported by PHPUnit 7).
Also symfony components are required to be 3.4 minimum (already EOL anyway, but not so old).