### PR TITLE
Migrate travis to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  run-tests:
+
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          include:
+          - php-version: 8.0.*
+            symfony-version: 6.0.*
+          - php-version: 8.0
+            symfony-version: 5.0.*
+          - php-version: 8.0
+            symfony-version: 4.4.*
+          - php-version: 7.4
+            symfony-version: 5.0.*
+          - php-version: 7.4
+            symfony-version: 4.4.*
+          - php-version: 7.4
+            symfony-version: 4.3.*
+          - php-version: 7.3
+            symfony-version: 5.0.*
+          - php-version: 7.3
+            symfony-version: 4.4.*
+          - php-version: 7.3
+            symfony-version: 4.3.*
+          - php-version: 7.2
+            symfony-version: 4.2.*
+          - php-version: 7.1
+            symfony-version: 3.4.*
+          - php-version: 7.1
+            symfony-version: 2.8.*
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+           php-version: ${{ matrix.php-version }}
+           ini-values: phar.readonly=0
+    - name: Git config email
+      run: git config --global user.email "test@test.com"
+    - name: Git config name
+      run: git config --global user.name "John Doe"
+    - name: Install Dependencies
+      run: |
+        composer self-update
+        composer require "symfony/console:${{ matrix.symfony-version }}" "symfony/yaml:${{ matrix.symfony-version }}" "symfony/process:${{ matrix.symfony-version }}" --no-update;
+        composer update --prefer-dist
+        composer require "phpunit/phpunit" --dev
+    - name: Execute tests (Unit and Feature tests) via PHPUnit
+      run: bin/phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   run-tests:
-
     runs-on: ubuntu-latest
     strategy:
         matrix:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RMT - Release Management Tool
 =============================
 
-[![Build Status](https://secure.travis-ci.org/liip/RMT.png?branch=master)](https://travis-ci.org/liip/RMT)
+[![Build Status](https://github.com/liip/rmt/actions/workflows/test.yml/badge.svg)](https://github.com/liip/rmt/actions/workflows/test.yml)
 [![Latest Stable Version](https://poser.pugx.org/liip/RMT/version.png)](https://packagist.org/packages/liip/RMT)
 [![Total Downloads](https://poser.pugx.org/liip/RMT/d/total.png)](https://packagist.org/packages/liip/RMT)
 [![License](https://poser.pugx.org/liip/rmt/license.svg)](https://packagist.org/packages/liip/rmt)


### PR DESCRIPTION
I've migrated the travis tests to GitHub actions, (I see there is another PR on this topic: https://github.com/liip/RMT/pull/168)

In this PR the tests for php8 and symfony console v6 are failing, but merging the https://github.com/liip/RMT/pull/167 fixes all the issues, I tested it in my fork.

Btw thanks for this nice tool! I use it regularly and I am very happy with it!