### PR TITLE
Ticket #173: prevent PHP 8.2 deprecation warnings.

### DIFF
--- a/src/Liip/RMT/Application.php
+++ b/src/Liip/RMT/Application.php
@@ -156,7 +156,7 @@ class Application extends BaseApplication
             if (in_array($name, array('list', 'help'))) {
                 continue;
             }
-            $messages[] = sprintf("  <info>%-${width}s</info> %s", $name, $command->getDescription());
+            $messages[] = sprintf("  <info>%-{$width}s</info> %s", $name, $command->getDescription());
         }
         $messages[] = '';
 

--- a/src/Liip/RMT/Config/Handler.php
+++ b/src/Liip/RMT/Config/Handler.php
@@ -16,6 +16,10 @@ namespace Liip\RMT\Config;
  */
 class Handler
 {
+    protected $rawConfig;
+
+    protected $projectRoot;
+
     public function __construct($rawConfig = null, $projectRoot = null)
     {
         $this->rawConfig = $rawConfig;


### PR DESCRIPTION
Changes will make prevent these errors:

> Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /sites/xsm_version-bump/vendor/liip/rmt/src/Liip/RMT/Application.php on line 159

> Deprecated: Creation of dynamic property Liip\RMT\Config\Handler::$rawConfig is deprecated in /sites/xsm_version-bump/vendor/liip/rmt/src/Liip/RMT/Config/Handler.php on line 21

> Deprecated: Creation of dynamic property Liip\RMT\Config\Handler::$projectRoot is deprecated in /sites/xsm_version-bump/vendor/liip/rmt/src/Liip/RMT/Config/Handler.php on line 22
