### PR TITLE
PHP 8.4 has deprecated warnings

### DIFF
--- a/src/Liip/RMT/Application.php
+++ b/src/Liip/RMT/Application.php
@@ -72,7 +72,7 @@ class Application extends BaseApplication
     /**
      * {@inheritdoc}
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null): int
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null): int
     {
         return parent::run($input, new Output());
     }

--- a/src/Liip/RMT/Output/Output.php
+++ b/src/Liip/RMT/Output/Output.php
@@ -36,7 +36,7 @@ class Output extends ConsoleOutput
     /** @var DialogHelper|QuestionHelper */
     protected $dialogHelper = null;
 
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatterInterface $formatter = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, ?OutputFormatterInterface $formatter = null)
     {
         // Use our own formatter
         parent::__construct($verbosity, $decorated, $formatter);
@@ -115,7 +115,7 @@ class Output extends ConsoleOutput
 
     // when we drop symfony 2.3 support, we should switch to the new QuestionHelper (since 2.5) and see if we need these methods at all anymore
     // QuestionHelper does about the same as we do here.
-    public function askQuestion(InteractiveQuestion $question, $position = null, InputInterface $input = null)
+    public function askQuestion(InteractiveQuestion $question, $position = null, ?InputInterface $input = null)
     {
         $text = ($position !== null ? $position .') ' : null) . $question->getFormatedText();
 
@@ -145,7 +145,7 @@ class Output extends ConsoleOutput
     }
 
     // when we drop symfony 2.3 support, we should switch to the QuestionHelper (since 2.5) and drop this method as it adds no value
-    public function askConfirmation($text, InputInterface $input = null)
+    public function askConfirmation($text, ?InputInterface $input = null)
     {
         if ($this->dialogHelper instanceof QuestionHelper) {
             if (!$input) {


### PR DESCRIPTION
Prevent warning 'Implicitly marking parameter xx as nullable is deprecated' in PHP 8.4.