### PR TITLE
Add white-list to WorkingCopyCheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Prerequisite actions are executed before the interactive part.
 
 * `working-copy-check`: check that you don't have any VCS local changes
   * Option `allow-ignore`: allow the user to skip the check when doing a release with `--ignore-check`
+  * Option `allowed-modifications`: allow the user to specify which files may be modified (does not support add, delete, rename, etc.)
 * `display-last-changes`: display your last changes
 * `tests-check`: run the project test suite
   * Option `command`: command to run (default: *phpunit*)

--- a/test/Liip/RMT/Tests/Functional/PrerequisitesTest.php
+++ b/test/Liip/RMT/Tests/Functional/PrerequisitesTest.php
@@ -50,6 +50,23 @@ class PrerequisitesTest extends RMTFunctionalTestBase
         self::assertStringContainsString('local modification', implode("\n", $consoleOutput));
     }
 
+    public function testWorkingCopyContinuesWithAllowedModifications(): void
+    {
+        $this->createConfig('simple', 'vcs-tag', array(
+            'prerequisites' => array('working-copy-check'=>array('allowed-modifications'=>array('CHANGELOG'))),
+            'vcs' => 'git',
+        ));
+        $this->initGit();
+        exec('git tag 1');
+
+        // Release should continue even though file CHANGELOG has been modified.
+        exec('echo toto >> CHANGELOG');
+        exec('./RMT release -n 2>&1', $consoleOutput, $exitCode);
+        self::assertEquals(0, $exitCode, implode(PHP_EOL, $consoleOutput));
+        exec('git tag', $tags2);
+        self::assertEquals(array('1', '2'), $tags2);
+    }
+
     public function testWorkingCopyWithIgnoreCheck(): void
     {
         $this->createConfig('simple', 'vcs-tag', array(


### PR DESCRIPTION
This code change makes it possible to have working copy changes and still release. For instance a CHANGELOG file that must be committed with the release, but you don't want a separate CHANGELOG commit and version commit.

Only modified files will be checked, thus those that have the 'M' in a `status` list.

Works with Git and HG.

Configuration in .rmp.yml:

```yaml
     prerequisites:
        working-copy-check:
            allow-ignore: false
            allowed-modifications:
                - CHANGELOG.txt
                - magento/index.php
```